### PR TITLE
Add lua cosmo module tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,5 +17,5 @@ jobs:
           sudo cp build/bootstrap/ape.elf /usr/bin/ape
           sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
 
-      - name: Build lua
-        run: make -j$(nproc) MODE=rel o/rel/tool/lua/lua.dbg
+      - name: Build and test lua
+        run: make -j$(nproc) MODE=rel o/rel/tool/lua/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
             o/rel/third_party/make/make.dbg \
             o/rel/third_party/zip/zip.dbg \
             o/rel/third_party/unzip/unzip.dbg \
-            o/rel/tool/lua/lua.dbg
+            o/rel/tool/lua/lua.dbg \
+            o/rel/tool/lua/test
 
       - name: Prepare utilities
         run: |

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -82,7 +82,18 @@ o/$(MODE)/tool/lua/lua.dbg:						\
 
 $(TOOL_LUA_OBJS): tool/lua/BUILD.mk
 
+o/$(MODE)/tool/lua/test_cosmo.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_cosmo.lua
+	$< tool/lua/test_cosmo.lua
+	@touch $@
+
+TOOL_LUA_TESTS =							\
+	o/$(MODE)/tool/lua/test_cosmo.ok
+
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\
 		$(TOOL_LUA_BINS)					\
 		$(TOOL_LUA_CHECKS)
+
+.PHONY: o/$(MODE)/tool/lua/test
+o/$(MODE)/tool/lua/test:						\
+		$(TOOL_LUA_TESTS)

--- a/tool/lua/test_cosmo.lua
+++ b/tool/lua/test_cosmo.lua
@@ -1,0 +1,24 @@
+local cosmo = require("cosmo")
+
+assert(type(cosmo) == "table", "cosmo should be a table")
+
+-- test a few top-level functions exist
+assert(type(cosmo.DecodeJson) == "function", "DecodeJson should be a function")
+assert(type(cosmo.EncodeJson) == "function", "EncodeJson should be a function")
+assert(type(cosmo.Sha256) == "function", "Sha256 should be a function")
+
+-- test submodules exist
+assert(type(cosmo.unix) == "table", "cosmo.unix should be a table")
+assert(type(cosmo.path) == "table", "cosmo.path should be a table")
+assert(type(cosmo.re) == "table", "cosmo.re should be a table")
+assert(type(cosmo.argon2) == "table", "cosmo.argon2 should be a table")
+assert(type(cosmo.sqlite3) == "table", "cosmo.sqlite3 should be a table")
+
+-- test a function actually works
+local json = cosmo.EncodeJson({foo = "bar"})
+assert(json == '{"foo":"bar"}', "EncodeJson should produce valid JSON")
+
+local decoded = cosmo.DecodeJson('{"x":1}')
+assert(decoded.x == 1, "DecodeJson should parse JSON")
+
+print("all tests passed")


### PR DESCRIPTION
## Summary
- Add `tool/lua/test_cosmo.lua` with assert-based tests for cosmo module
- Add make target `o/$(MODE)/tool/lua/test`
- Run tests in PR and release workflows

## Test plan
- [ ] PR build runs lua test successfully