### PR TITLE
Add release make target with APE verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,23 +27,8 @@ jobs:
           sudo cp build/bootstrap/ape.elf /usr/bin/ape
           sudo sh -c "echo ':APE:M::MZqFpD::/usr/bin/ape:' >/proc/sys/fs/binfmt_misc/register"
 
-      - name: Build utilities
-        run: |
-          make -j$(nproc) MODE=rel \
-            o/rel/third_party/make/make.dbg \
-            o/rel/third_party/zip/zip.dbg \
-            o/rel/third_party/unzip/unzip.dbg \
-            o/rel/tool/lua/lua.dbg \
-            o/rel/tool/lua/test
-
-      - name: Prepare utilities
-        run: |
-          mkdir -p release/bin
-          objcopy -S -O binary o/rel/third_party/make/make.dbg release/bin/make
-          objcopy -S -O binary o/rel/third_party/zip/zip.dbg release/bin/zip
-          objcopy -S -O binary o/rel/third_party/unzip/unzip.dbg release/bin/unzip
-          objcopy -S -O binary o/rel/tool/lua/lua.dbg release/bin/lua
-          chmod +x release/bin/*
+      - name: Build and verify utilities
+        run: make -j$(nproc) MODE=rel o/rel/tool/lua/test o/rel/tool/release
 
       - name: Build cosmocc
         run: tool/cosmocc/package.sh cosmocc-build
@@ -56,10 +41,10 @@ jobs:
 
       - name: Create checksums
         run: |
-          cd release/bin
+          cd o/rel/tool/release/bin
           sha256sum make zip unzip lua > SHA256SUMS
-          cd ../..
-          sha256sum cosmocc.zip >> release/bin/SHA256SUMS
+          cd ../../../../..
+          sha256sum cosmocc.zip >> o/rel/tool/release/bin/SHA256SUMS
 
       - name: Create release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.2.0
@@ -68,10 +53,10 @@ jobs:
           name: ${{ steps.tag.outputs.tag }}
           files: |
             cosmocc.zip
-            release/bin/make
-            release/bin/zip
-            release/bin/unzip
-            release/bin/lua
-            release/bin/SHA256SUMS
+            o/rel/tool/release/bin/make
+            o/rel/tool/release/bin/zip
+            o/rel/tool/release/bin/unzip
+            o/rel/tool/release/bin/lua
+            o/rel/tool/release/bin/SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -361,6 +361,7 @@ include tool/plinko/BUILD.mk
 include test/tool/plinko/BUILD.mk
 include tool/net/BUILD.mk
 include tool/lua/BUILD.mk
+include tool/release/BUILD.mk
 include tool/viz/BUILD.mk
 include tool/BUILD.mk
 include net/turfwar/BUILD.mk

--- a/tool/release/BUILD.mk
+++ b/tool/release/BUILD.mk
@@ -1,0 +1,57 @@
+#-*-mode:makefile-gmake;indent-tabs-mode:t;tab-width:8;coding:utf-8-*-┐
+#── vi: set noet ft=make ts=8 sw=8 fenc=utf-8 :vi ────────────────────┘
+
+PKGS += TOOL_RELEASE
+
+RELEASE_BINS =								\
+	o/$(MODE)/tool/release/bin/lua					\
+	o/$(MODE)/tool/release/bin/make					\
+	o/$(MODE)/tool/release/bin/zip					\
+	o/$(MODE)/tool/release/bin/unzip
+
+RELEASE_CHECKS =							\
+	o/$(MODE)/tool/release/bin/lua.ok				\
+	o/$(MODE)/tool/release/bin/make.ok				\
+	o/$(MODE)/tool/release/bin/zip.ok				\
+	o/$(MODE)/tool/release/bin/unzip.ok
+
+o/$(MODE)/tool/release/bin/lua: o/$(MODE)/tool/lua/lua.dbg
+	@mkdir -p $(@D)
+	cp $< $@
+
+o/$(MODE)/tool/release/bin/make: o/$(MODE)/third_party/make/make.dbg
+	@mkdir -p $(@D)
+	cp $< $@
+
+o/$(MODE)/tool/release/bin/zip: o/$(MODE)/third_party/zip/zip.dbg
+	@mkdir -p $(@D)
+	cp $< $@
+
+o/$(MODE)/tool/release/bin/unzip: o/$(MODE)/third_party/unzip/unzip.dbg
+	@mkdir -p $(@D)
+	cp $< $@
+
+o/$(MODE)/tool/release/bin/lua.ok: o/$(MODE)/tool/release/bin/lua
+	$< -v
+	grep -q MZqFpD $<
+	@touch $@
+
+o/$(MODE)/tool/release/bin/make.ok: o/$(MODE)/tool/release/bin/make
+	$< --version
+	grep -q MZqFpD $<
+	@touch $@
+
+o/$(MODE)/tool/release/bin/zip.ok: o/$(MODE)/tool/release/bin/zip
+	$< -v
+	grep -q MZqFpD $<
+	@touch $@
+
+o/$(MODE)/tool/release/bin/unzip.ok: o/$(MODE)/tool/release/bin/unzip
+	$< -v
+	grep -q MZqFpD $<
+	@touch $@
+
+.PHONY: o/$(MODE)/tool/release
+o/$(MODE)/tool/release:							\
+		$(RELEASE_BINS)						\
+		$(RELEASE_CHECKS)


### PR DESCRIPTION
## Summary
- Add `tool/release/BUILD.mk` with release binary targets
- Use `cp` instead of `objcopy -S -O binary` to preserve APE format
- Verify binaries execute and contain APE magic (`MZqFpD`)
- Update release workflow to use `make o/rel/tool/release`

## Test plan
- [x] `make MODE=rel o/rel/tool/release` passes locally
- [ ] Release workflow creates valid APE binaries