### PR TITLE
lua: add .args to enable zip appending

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -76,6 +76,7 @@ o/$(MODE)/tool/lua/lua.dbg:						\
 		$(TOOL_LUA_DEPS)					\
 		$(TOOL_LUA_LUA_MODULES)					\
 		o/$(MODE)/tool/lua/lua.main.o				\
+		o/$(MODE)/tool/lua/.args.zip.o				\
 		$(CRT)							\
 		$(APE_NO_MODIFY_SELF)
 	@$(APELINK)


### PR DESCRIPTION
## Summary
- Adds empty `.args` file to `tool/lua/` to enable zip appending
- Updates `BUILD.mk` to include `.args.zip.o` in lua.dbg dependencies

## Test plan
- [ ] Build lua target and verify .args is included in the zip