### PR TITLE
Fix concurrent HTTPS fetch failures after fork

### DIFF
--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -9,6 +9,19 @@
 #define kaKEEP  2
 #define kaCLOSE 3
 
+// Reset TLS state after fork so child processes get fresh entropy/DRBG
+// Called automatically by Fetch() when resettls=true (the default)
+// Includers can define HAVE_LUA_RESET_FETCH_TLS_STATE to provide their own
+#if !defined(HAVE_LUA_RESET_FETCH_TLS_STATE) && !defined(UNSECURE)
+static void LuaResetFetchTlsState(void) {
+  if (sslinitialized) {
+    mbedtls_ctr_drbg_free(&rngcli);
+    mbedtls_ssl_config_free(&confcli);
+    sslinitialized = false;
+  }
+}
+#endif
+
 int LuaFetch(lua_State *L) {
 #define ssl nope  // TODO(jart): make this file less huge
   ssize_t rc;
@@ -40,6 +53,9 @@ int LuaFetch(lua_State *L) {
   uint64_t imethod;
   int numredirects = 0, maxredirects = 5;
   bool followredirect = true;
+#ifndef UNSECURE
+  bool resettls = true;
+#endif
   size_t maxresponse = 100 * 1024 * 1024;  // 100MB default limit
   struct addrinfo hints = {.ai_family = AF_INET,
                            .ai_socktype = SOCK_STREAM,
@@ -76,6 +92,11 @@ int LuaFetch(lua_State *L) {
     lua_getfield(L, 2, "maxresponse");
     if (lua_isinteger(L, -1))
       maxresponse = lua_tointeger(L, -1);
+#ifndef UNSECURE
+    lua_getfield(L, 2, "resettls");
+    if (lua_isboolean(L, -1))
+      resettls = lua_toboolean(L, -1);
+#endif
     lua_getfield(L, 2, "keepalive");
     if (!lua_isnil(L, -1)) {
       if (lua_istable(L, -1)) {
@@ -173,6 +194,8 @@ int LuaFetch(lua_State *L) {
 #ifndef UNSECURE
   if (usingssl)
     keepalive = kaNONE;
+  if (usingssl && resettls)
+    LuaResetFetchTlsState();
   if (usingssl && !sslinitialized)
     TlsInit();
 #endif


### PR DESCRIPTION
## Summary

- Add `resettls` parameter to `Fetch()` that defaults to `true`, automatically resetting TLS state before each HTTPS request
- Fixes ~25% failure rate when making concurrent HTTPS requests from forked child processes

## Root Cause

mbedtls global DRBG/entropy state is shared after `fork()`, causing TLS handshakes to fail or produce corrupted data when multiple child processes use HTTPS concurrently.

## Solution

Add `LuaResetFetchTlsState()` to both `lfetch.c` and `redbean.c`, which frees the inherited TLS config/DRBG state. This is called automatically before `TlsInit()` when `resettls=true` (the default).

## API

```lua
-- Safe by default - works after fork
Fetch("https://example.com/")

-- Opt out for performance (when not forking)
Fetch("https://example.com/", {resettls = false})
```

## Test plan

- [x] Build succeeds: `make o//tool/net/redbean`
- [x] Concurrent HTTPS fetches after fork: 4/4 succeed (was ~75%)
- [x] Sequential fetches with `resettls=false`: works correctly