### PR TITLE
Fix ParseHttpMessage position tracking across incremental reads

### DIFF
--- a/net/http/parsehttpmessage.c
+++ b/net/http/parsehttpmessage.c
@@ -316,7 +316,13 @@ int ParseHttpMessage(struct HttpMessage *r, const char *p, size_t n, size_t c) {
         __builtin_unreachable();
     }
   }
-  if (r->i < c)
+  if (r->i < c) {
+    // Clamp position to not skip past buffer end.
+    // Inner loops may set r->i = n, then outer for loop increments to n+1.
+    // On resume we want to start at position n, not n+1.
+    if (r->i > n)
+      r->i = n;
     return 0;
+  }
   return ebadmsg();
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where `ParseHttpMessage` would skip bytes when HTTP headers span multiple reads
- The parser's inner loops increment `r->i` to buffer end, then outer loop increments again, causing position `n` to be skipped on resume
- This caused parse failures with large headers (~5KB) like GitHub's Content-Security-Policy

## Test plan

- [x] Fork stress test: 12/12 pass (was 9/12 before fix)
- [x] lfetch test suite: 17/19 pass (2 failures are expected httpbin.org HTTPS→HTTP protection)
- [x] GitHub release download tests pass