### PR TITLE
Fix Lua format specifier in LuaNilError call

### DIFF
--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -405,7 +405,7 @@ int LuaFetch(lua_State *L) {
         close(sock);
         free(inbuf.p);
         DestroyHttpMessage(&msg);
-        return LuaNilError(L, "response too large (max %zu bytes)", maxresponse);
+        return LuaNilError(L, "response too large (max %I bytes)", (lua_Integer)maxresponse);
       }
       if (!(newp = realloc(inbuf.p, inbuf.c))) {
 #ifndef UNSECURE


### PR DESCRIPTION
## Summary
- Use `%I` (lua_Integer) instead of `%zu` (size_t) for the maxresponse error message
- redbean.c's `LuaNilError` uses `lua_pushvfstring` which only supports Lua's format specifiers, not C's `%zu`

## Problem
When downloading files larger than `maxresponse` (default 100MB), the error path would crash with:
```
invalid option '%z' to 'lua_pushfstring'
```

## Test plan
- [x] Verified fix with `Fetch("https://release-assets.githubusercontent.com/...")` for a 137MB file
- [x] Error message now correctly displays: `response too large (max 104857600 bytes)`
- [x] Downloads work with `{maxresponse = 200*1024*1024}` option