### PR TITLE
Load system CA certificates for TLS verification

### DIFF
--- a/net/https/getsslroots.c
+++ b/net/https/getsslroots.c
@@ -21,6 +21,7 @@
 #include "libc/cosmo.h"
 #include "libc/limits.h"
 #include "libc/mem/mem.h"
+#include "libc/runtime/runtime.h"
 #include "libc/str/str.h"
 #include "libc/sysv/consts/dt.h"
 #include "libc/sysv/consts/o.h"
@@ -29,6 +30,15 @@
 __static_yoink("ssl_root_support");
 
 #define SSL_ROOT_DIR "/zip/usr/share/ssl/root"
+
+// Common system CA certificate bundle locations
+static const char *const kSystemCaPaths[] = {
+    "/etc/ssl/certs/ca-certificates.crt",      // Debian/Ubuntu
+    "/etc/pki/tls/certs/ca-bundle.crt",        // RHEL/CentOS
+    "/etc/ssl/ca-bundle.pem",                  // OpenSUSE
+    "/usr/local/share/certs/ca-root-nss.crt",  // FreeBSD
+    "/etc/ssl/cert.pem",                       // Alpine/macOS
+};
 
 static struct {
   _Atomic(uint32_t) once;
@@ -39,35 +49,82 @@ static void FreeSslRoots(void) {
   mbedtls_x509_crt_free(&g_ssl_roots.chain);
 }
 
-static void InitSslRoots(void) {
+// Load certificates from a single PEM file
+// Returns number of certificates loaded, or 0 on failure
+static int LoadCertsFromFile(const char *path) {
+  int fd, loaded = 0;
+  size_t size;
+  uint8_t *data;
+  if ((fd = open(path, O_RDONLY)) == -1) {
+    return 0;
+  }
+  size = lseek(fd, 0, SEEK_END);
+  if (size > 0 && size < 16 * 1024 * 1024 &&  // sanity limit: 16MB
+      (data = calloc(1, size + 1)) != NULL) {
+    if (pread(fd, data, size, 0) == (ssize_t)size) {
+      int rc = mbedtls_x509_crt_parse(&g_ssl_roots.chain, data, size + 1);
+      if (rc >= 0) {
+        // rc is number of certs that failed to parse; success if not all failed
+        loaded = 1;
+      }
+    }
+    free(data);
+  }
+  close(fd);
+  return loaded;
+}
+
+// Load certificates from a directory of PEM files
+static void LoadCertsFromDir(const char *dirpath) {
   DIR *dir;
-  if (!(dir = opendir(SSL_ROOT_DIR))) {
-    perror(SSL_ROOT_DIR);
+  struct dirent *ent;
+  char path[PATH_MAX];
+  if (!(dir = opendir(dirpath))) {
     return;
   }
-  struct dirent *ent;
   while ((ent = readdir(dir))) {
-    if (ent->d_type != DT_REG &&  //
-        ent->d_type != DT_UNKNOWN) {
+    if (ent->d_type != DT_REG && ent->d_type != DT_UNKNOWN) {
       continue;
     }
-    char path[PATH_MAX];
-    strlcpy(path, SSL_ROOT_DIR "/", sizeof(path));
+    strlcpy(path, dirpath, sizeof(path));
+    strlcat(path, "/", sizeof(path));
     strlcat(path, ent->d_name, sizeof(path));
     uint8_t *data;
-    int fd = open(path, O_RDONLY);         // punt error to lseek
-    size_t size = lseek(fd, 0, SEEK_END);  // punt error to calloc
-    if ((data = calloc(1, size + 1)) && pread(fd, data, size, 0) == size) {
+    int fd = open(path, O_RDONLY);
+    size_t size = lseek(fd, 0, SEEK_END);
+    if ((data = calloc(1, size + 1)) && pread(fd, data, size, 0) == (ssize_t)size) {
       if (mbedtls_x509_crt_parse(&g_ssl_roots.chain, data, size + 1)) {
-        tinyprint(2, path, ": error loading ssl root\n", NULL);
+        // Individual cert parse error is not fatal
       }
-    } else {
-      perror(path);
     }
     free(data);
     close(fd);
   }
   closedir(dir);
+}
+
+static void InitSslRoots(void) {
+  const char *env_cert_file;
+  size_t i;
+
+  // Skip system CA loading if SSL_NO_SYSTEM_CERTS is set
+  if (!getenv("SSL_NO_SYSTEM_CERTS")) {
+    // First, try SSL_CERT_FILE environment variable
+    if ((env_cert_file = getenv("SSL_CERT_FILE")) != NULL) {
+      LoadCertsFromFile(env_cert_file);
+    } else {
+      // Then try common system CA bundle locations
+      for (i = 0; i < sizeof(kSystemCaPaths) / sizeof(kSystemCaPaths[0]); i++) {
+        if (LoadCertsFromFile(kSystemCaPaths[i])) {
+          break;
+        }
+      }
+    }
+  }
+
+  // Always load embedded certificates as supplement/fallback
+  LoadCertsFromDir(SSL_ROOT_DIR);
+
   atexit(FreeSslRoots);
 }
 

--- a/test/tool/net/lfetch_test.lua
+++ b/test/tool/net/lfetch_test.lua
@@ -525,6 +525,296 @@ function test_proxy_host_header()
     print("test_proxy_host_header: PASS")
 end
 
+--------------------------------------------------------------------------------
+-- Proxy Authentication Tests
+-- These tests verify that Fetch correctly handles authenticated proxy URLs
+-- in the format: http://username:password@host:port
+--------------------------------------------------------------------------------
+
+-- Helper: Base64 encode (for verifying Proxy-Authorization header)
+local function base64_encode(data)
+    local b = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+    return ((data:gsub('.', function(x)
+        local r, b = '', x:byte()
+        for i = 8, 1, -1 do r = r .. (b % 2 ^ i - b % 2 ^ (i - 1) > 0 and '1' or '0') end
+        return r
+    end) .. '0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if #x < 6 then return '' end
+        local c = 0
+        for i = 1, 6 do c = c + (x:sub(i, i) == '1' and 2 ^ (6 - i) or 0) end
+        return b:sub(c + 1, c + 1)
+    end) .. ({ '', '==', '=' })[#data % 3 + 1])
+end
+
+-- Test: HTTP proxy with Basic auth sends Proxy-Authorization header
+function test_proxy_basic_auth_http()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    local pid = unix.fork()
+    if pid == 0 then
+        local request = handle_one_request(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK", 5000)
+        local f = io.open("/tmp/proxy_auth_http.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    Fetch("http://example.com/test", {
+        proxy = "http://testuser:testpass@127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_auth_http.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_auth_http.txt")
+    end
+
+    assert(captured_request, "failed to capture request")
+    -- Expected: Proxy-Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
+    local expected_auth = "Basic " .. base64_encode("testuser:testpass")
+    assert(captured_request:find("Proxy%-Authorization: " .. expected_auth, 1, false),
+           "expected Proxy-Authorization header with Basic auth, got:\n" .. captured_request:sub(1, 500))
+    print("test_proxy_basic_auth_http: PASS")
+end
+
+-- Test: HTTPS proxy with Basic auth sends Proxy-Authorization in CONNECT
+function test_proxy_basic_auth_https_connect()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    local pid = unix.fork()
+    if pid == 0 then
+        -- Send 200 Connection Established to allow CONNECT to succeed
+        local request = handle_one_request(server, "HTTP/1.1 200 Connection Established\r\n\r\n", 5000)
+        local f = io.open("/tmp/proxy_auth_connect.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    -- This will fail after CONNECT (no real TLS), but we can verify auth header
+    Fetch("https://secure.example.com/path", {
+        proxy = "http://proxyuser:proxypass@127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_auth_connect.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_auth_connect.txt")
+    end
+
+    assert(captured_request, "failed to capture CONNECT request")
+    -- Verify CONNECT request contains Proxy-Authorization
+    local expected_auth = "Basic " .. base64_encode("proxyuser:proxypass")
+    assert(captured_request:find("^CONNECT "),
+           "expected CONNECT request, got:\n" .. captured_request:sub(1, 200))
+    assert(captured_request:find("Proxy%-Authorization: " .. expected_auth, 1, false),
+           "expected Proxy-Authorization in CONNECT request, got:\n" .. captured_request:sub(1, 500))
+    print("test_proxy_basic_auth_https_connect: PASS")
+end
+
+-- Test: Proxy auth with special characters in password
+function test_proxy_auth_special_chars()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    local pid = unix.fork()
+    if pid == 0 then
+        local request = handle_one_request(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK", 5000)
+        local f = io.open("/tmp/proxy_auth_special.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    -- Password with special chars that need URL encoding: p@ss:word/test
+    -- In URL: p%40ss%3Aword%2Ftest
+    Fetch("http://example.com/test", {
+        proxy = "http://user:p%40ss%3Aword%2Ftest@127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_auth_special.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_auth_special.txt")
+    end
+
+    assert(captured_request, "failed to capture request")
+    -- The decoded credentials should be: user:p@ss:word/test
+    local expected_auth = "Basic " .. base64_encode("user:p@ss:word/test")
+    assert(captured_request:find("Proxy%-Authorization: " .. expected_auth, 1, false),
+           "expected Proxy-Authorization with decoded special chars, got:\n" .. captured_request:sub(1, 500))
+    print("test_proxy_auth_special_chars: PASS")
+end
+
+-- Test: Proxy auth with long JWT-style password (400+ chars)
+function test_proxy_auth_long_jwt_password()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    -- Simulate a JWT-like token (400+ chars)
+    local jwt_password = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9." ..
+        string.rep("abcdefghijklmnopqrstuvwxyz0123456789", 12) ..
+        ".signature_part_here"
+
+    local pid = unix.fork()
+    if pid == 0 then
+        local request = handle_one_request(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK", 5000)
+        local f = io.open("/tmp/proxy_auth_jwt.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    Fetch("http://example.com/test", {
+        proxy = "http://container_id:" .. jwt_password .. "@127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_auth_jwt.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_auth_jwt.txt")
+    end
+
+    assert(captured_request, "failed to capture request")
+    local expected_auth = "Basic " .. base64_encode("container_id:" .. jwt_password)
+    assert(captured_request:find("Proxy%-Authorization:", 1, true),
+           "expected Proxy-Authorization header, got:\n" .. captured_request:sub(1, 500))
+    -- Verify the full auth value is present
+    assert(captured_request:find(expected_auth, 1, true),
+           "expected correct Base64-encoded JWT credentials")
+    print("test_proxy_auth_long_jwt_password: PASS")
+end
+
+-- Test: Proxy URL with username but no password
+function test_proxy_auth_username_only()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    local pid = unix.fork()
+    if pid == 0 then
+        local request = handle_one_request(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK", 5000)
+        local f = io.open("/tmp/proxy_auth_useronly.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    -- Username with no password: http://onlyuser@host:port
+    Fetch("http://example.com/test", {
+        proxy = "http://onlyuser@127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_auth_useronly.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_auth_useronly.txt")
+    end
+
+    assert(captured_request, "failed to capture request")
+    -- Even with no password, should send auth header with "onlyuser:"
+    local expected_auth = "Basic " .. base64_encode("onlyuser:")
+    assert(captured_request:find("Proxy%-Authorization: " .. expected_auth, 1, false),
+           "expected Proxy-Authorization with username only, got:\n" .. captured_request:sub(1, 500))
+    print("test_proxy_auth_username_only: PASS")
+end
+
+-- Test: Proxy URL without credentials should NOT send Proxy-Authorization
+function test_proxy_no_auth_no_header()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    local pid = unix.fork()
+    if pid == 0 then
+        local request = handle_one_request(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK", 5000)
+        local f = io.open("/tmp/proxy_no_auth.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    -- No credentials in proxy URL
+    Fetch("http://example.com/test", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_no_auth.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_no_auth.txt")
+    end
+
+    assert(captured_request, "failed to capture request")
+    -- Should NOT contain Proxy-Authorization header
+    assert(not captured_request:find("Proxy%-Authorization:", 1, true),
+           "expected NO Proxy-Authorization header for unauthenticated proxy, got:\n" .. captured_request:sub(1, 500))
+    print("test_proxy_no_auth_no_header: PASS")
+end
+
+-- Test: Proxy auth credentials are NOT sent to target server (security)
+function test_proxy_auth_not_leaked_to_target()
+    local server, port = create_test_server()
+    local captured_request = nil
+
+    local pid = unix.fork()
+    if pid == 0 then
+        local request = handle_one_request(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK", 5000)
+        local f = io.open("/tmp/proxy_auth_leak.txt", "w")
+        if f and request then f:write(request); f:close() end
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    Fetch("http://example.com/test", {
+        proxy = "http://secretuser:secretpass@127.0.0.1:" .. port
+    })
+
+    unix.wait(pid)
+
+    local f = io.open("/tmp/proxy_auth_leak.txt", "r")
+    if f then
+        captured_request = f:read("*a")
+        f:close()
+        os.remove("/tmp/proxy_auth_leak.txt")
+    end
+
+    assert(captured_request, "failed to capture request")
+    -- The proxy URL credentials should appear in Proxy-Authorization, NOT in Authorization
+    assert(not captured_request:find("Authorization: Basic", 1, true) or
+           captured_request:find("Proxy%-Authorization:", 1, true),
+           "credentials should only appear in Proxy-Authorization, not Authorization")
+    -- The raw credentials should not appear anywhere in the request
+    assert(not captured_request:find("secretuser:secretpass", 1, true),
+           "raw credentials should not appear in request")
+    print("test_proxy_auth_not_leaked_to_target: PASS")
+end
+
 -- Test: GitHub release download (known issue - long Location header with JWT tokens)
 -- This URL redirects with a ~968 byte Location header containing signed URLs
 function test_github_release_download()
@@ -611,6 +901,14 @@ function main()
         test_proxy_option_overrides_env,
         test_proxy_custom_port,
         test_proxy_host_header,
+        -- Proxy authentication tests
+        test_proxy_basic_auth_http,
+        test_proxy_basic_auth_https_connect,
+        test_proxy_auth_special_chars,
+        test_proxy_auth_long_jwt_password,
+        test_proxy_auth_username_only,
+        test_proxy_no_auth_no_header,
+        test_proxy_auth_not_leaked_to_target,
     }
 
     local passed = 0

--- a/test/tool/net/lfetch_test.lua
+++ b/test/tool/net/lfetch_test.lua
@@ -695,7 +695,7 @@ function test_proxy_auth_long_jwt_password()
 
     assert(captured_request, "failed to capture request")
     local expected_auth = "Basic " .. base64_encode("container_id:" .. jwt_password)
-    assert(captured_request:find("Proxy%-Authorization:", 1, true),
+    assert(captured_request:find("Proxy-Authorization:", 1, true),
            "expected Proxy-Authorization header, got:\n" .. captured_request:sub(1, 500))
     -- Verify the full auth value is present
     assert(captured_request:find(expected_auth, 1, true),
@@ -771,7 +771,7 @@ function test_proxy_no_auth_no_header()
 
     assert(captured_request, "failed to capture request")
     -- Should NOT contain Proxy-Authorization header
-    assert(not captured_request:find("Proxy%-Authorization:", 1, true),
+    assert(not captured_request:find("Proxy-Authorization:", 1, true),
            "expected NO Proxy-Authorization header for unauthenticated proxy, got:\n" .. captured_request:sub(1, 500))
     print("test_proxy_no_auth_no_header: PASS")
 end
@@ -806,8 +806,10 @@ function test_proxy_auth_not_leaked_to_target()
 
     assert(captured_request, "failed to capture request")
     -- The proxy URL credentials should appear in Proxy-Authorization, NOT in Authorization
-    assert(not captured_request:find("Authorization: Basic", 1, true) or
-           captured_request:find("Proxy%-Authorization:", 1, true),
+    -- Check that there's no standalone "Authorization:" header (not Proxy-Authorization:)
+    local has_plain_auth = captured_request:find("\nAuthorization:", 1, true)
+    local has_proxy_auth = captured_request:find("Proxy-Authorization:", 1, true)
+    assert(not has_plain_auth or has_proxy_auth,
            "credentials should only appear in Proxy-Authorization, not Authorization")
     -- The raw credentials should not appear anywhere in the request
     assert(not captured_request:find("secretuser:secretpass", 1, true),

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -34,6 +34,7 @@ int LuaFetch(lua_State *L) {
   const char *proxyhost = 0, *proxyport = 0;
   const char *proxyarg = 0;
   size_t proxyarglen = 0;
+  char *proxyauthhdr = 0;
   char *request;
   struct TlsBio *bio;
   mbedtls_ssl_context sslctx;
@@ -248,6 +249,18 @@ int LuaFetch(lua_State *L) {
     DEBUGF("(ftch) using proxy %s:%s", proxyhost, proxyport);
     // Disable keepalive when using proxy for simplicity
     keepalive = kaNONE;
+    // Build Proxy-Authorization header if credentials present
+    if (proxyurl.user.n) {
+      char *creds = gc(xasprintf("%.*s:%.*s",
+                                 (int)proxyurl.user.n, proxyurl.user.p,
+                                 (int)proxyurl.pass.n, proxyurl.pass.p));
+      size_t credslen = strlen(creds);
+      char *b64 = gc(EncodeBase64(creds, credslen, 0));
+      if (b64) {
+        proxyauthhdr = gc(xasprintf("Proxy-Authorization: Basic %s\r\n", b64));
+        DEBUGF("(ftch) using proxy authentication");
+      }
+    }
   }
 
   if (url.host.n) {
@@ -321,13 +334,15 @@ int LuaFetch(lua_State *L) {
           "Host: %s\r\n"
           "Connection: %s\r\n"
           "User-Agent: %s\r\n"
-          "%s%s"
+          "%s%s%s"
           "\r\n",
           method, gc(EncodeUrl(&url, 0)), hosthdr,
           (keepalive == kaNONE || keepalive == kaCLOSE)
               ? "close"
               : (connhdr ? connhdr : "keep-alive"),
-          agenthdr, conlenhdr, headers ? headers : "");
+          agenthdr, conlenhdr,
+          (proxyhost && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
+          headers ? headers : "");
   appendd(&request, body, bodylen);
   requestlen = appendz(request).i;
   gc(request);
@@ -387,8 +402,10 @@ int LuaFetch(lua_State *L) {
             "Host: %s:%s\r\n"
             "User-Agent: %s\r\n"
             "Proxy-Connection: keep-alive\r\n"
+            "%s"
             "\r\n",
-            host, port, host, port, agenthdr);
+            host, port, host, port, agenthdr,
+            proxyauthhdr ? proxyauthhdr : "");
     size_t connectreqlen = appendz(connectreq).i;
     gc(connectreq);
     DEBUGF("(ftch) sending CONNECT %s:%s to proxy", host, port);


### PR DESCRIPTION
## Summary

- Load CA certificates from system paths in addition to embedded certs
- Respect `SSL_CERT_FILE` environment variable
- Add `SSL_NO_SYSTEM_CERTS=1` to use only embedded certificates

## Background

`GetSslRoots()` previously only loaded certificates from `/zip/usr/share/ssl/root/`. This caused TLS verification failures in environments with SSL-intercepting proxies (corporate networks, container environments), since the proxy's CA is installed on the system but not embedded.

See: https://github.com/whilp/dotfiles/blob/cad9cf248de5d68b8dd92574ca3b894b9d135e59/docs/cosmo-fetch-proxy-tls.md

## Changes

Certificate loading order:
1. `SSL_CERT_FILE` env var (if set)
2. System CA bundle paths:
   - `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu)
   - `/etc/pki/tls/certs/ca-bundle.crt` (RHEL/CentOS)
   - `/etc/ssl/ca-bundle.pem` (OpenSUSE)
   - `/usr/local/share/certs/ca-root-nss.crt` (FreeBSD)
   - `/etc/ssl/cert.pem` (Alpine/macOS)
3. Embedded certs (always loaded as fallback)

Set `SSL_NO_SYSTEM_CERTS=1` to skip system paths.

## Test plan

- [x] HTTPS works with `SSL_CERT_FILE` set
- [x] HTTPS works without `SSL_CERT_FILE` (uses system paths)
- [x] HTTPS works with `SSL_NO_SYSTEM_CERTS=1` (embedded only)
- [x] All 40 lfetch tests pass

**Note:** This PR includes the proxy authentication commits from PR #17.