### PR TITLE
Fix Docker tagging: ensure 'latest' points to cosmo releases

### DIFF
--- a/.github/workflows/release-cosmocc.yml
+++ b/.github/workflows/release-cosmocc.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: ${{ steps.tag.outputs.tag }}
+          prerelease: true
           files: |
             cosmocc.zip
             SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,3 +95,10 @@ jobs:
             o/fat/bin/SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update latest tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f latest
+          git push origin latest --force


### PR DESCRIPTION
- Mark cosmocc releases as pre-releases to prevent them from being designated as GitHub's "latest" release
- Add explicit 'latest' tag management to cosmo workflow to ensure it always points to the most recent cosmo release
- Both release types continue to be created, but with clear separation

This resolves the issue where 'latest' could unpredictably point to either cosmo or cosmocc depending on which workflow finished last.