### PR TITLE
Add --skill option to install Claude Code skill

### DIFF
--- a/tool/lua/.lua/cosmo/help/init.lua
+++ b/tool/lua/.lua/cosmo/help/init.lua
@@ -173,6 +173,11 @@ local function load_definitions()
   help._loaded = true
 end
 
+-- Public function to ensure definitions are loaded (for programmatic access)
+function help.load()
+  load_definitions()
+end
+
 -- Register function->name mappings for help(func) support
 function help.register(tbl, prefix)
   if type(tbl) ~= "table" then return end

--- a/tool/lua/.lua/cosmo/skill/init.lua
+++ b/tool/lua/.lua/cosmo/skill/init.lua
@@ -1,0 +1,271 @@
+-- skill module for cosmo lua
+-- Generates and installs a Claude Code skill with documentation
+
+local skill = {}
+
+local SKILL_NAME = "cosmo-lua"
+
+local SKILL_MD_HEADER = [[---
+name: cosmo-lua
+description: Use cosmopolitan Lua (cosmo-lua) for portable scripts. Download from whilp/cosmopolitan releases. Includes unix syscalls, path utils, regex, sqlite, argon2.
+allowed-tools: [Read, Write, Edit, Bash, Glob, Grep, WebFetch]
+---
+
+# Cosmo Lua
+
+Portable Lua with batteries included from [whilp/cosmopolitan](https://github.com/whilp/cosmopolitan).
+
+## Installation
+
+Download the latest `lua` binary from [releases](https://github.com/whilp/cosmopolitan/releases):
+
+```bash
+curl -L -o lua https://github.com/whilp/cosmopolitan/releases/latest/download/lua
+chmod +x lua
+```
+
+The binary runs on Linux, macOS, Windows, FreeBSD, OpenBSD, and NetBSD without dependencies.
+
+## Update
+
+Download the latest release and reinstall the skill:
+
+```bash
+curl -L -o lua https://github.com/whilp/cosmopolitan/releases/latest/download/lua
+chmod +x lua
+./lua --skill
+```
+
+## Built-in help
+
+Use the interactive help system:
+
+```lua
+local help = require("cosmo.help")
+help()                    -- overview
+help("cosmo")             -- list module
+help("cosmo.Fetch")       -- function docs
+help.search("base64")     -- search
+```
+
+## Modules
+
+]]
+
+-- Format a documentation entry for markdown
+local function format_doc_md(name, doc)
+  local lines = {}
+
+  -- Function name as header
+  local short_name = name:match("([^%.]+)$") or name
+  table.insert(lines, "### " .. short_name)
+  table.insert(lines, "")
+
+  -- Signature in code block
+  table.insert(lines, "```lua")
+  table.insert(lines, doc.signature)
+  table.insert(lines, "```")
+  table.insert(lines, "")
+
+  -- Description
+  if doc.desc and doc.desc ~= "" then
+    for desc_line in doc.desc:gmatch("[^\n]+") do
+      table.insert(lines, desc_line:match("^%s*(.*)$"))
+    end
+    table.insert(lines, "")
+  end
+
+  -- Parameters
+  if #doc.params > 0 then
+    table.insert(lines, "**Parameters:**")
+    table.insert(lines, "")
+    for _, param in ipairs(doc.params) do
+      local optional = param.name:match("%?$") and " *(optional)*" or ""
+      local clean_name = param.name:gsub("%?$", "")
+      if param.desc ~= "" then
+        table.insert(lines, string.format("- `%s` (%s)%s: %s", clean_name, param.type, optional, param.desc))
+      else
+        table.insert(lines, string.format("- `%s` (%s)%s", clean_name, param.type, optional))
+      end
+    end
+    table.insert(lines, "")
+  end
+
+  -- Returns
+  if #doc.returns > 0 then
+    table.insert(lines, "**Returns:**")
+    table.insert(lines, "")
+    for _, ret in ipairs(doc.returns) do
+      if ret.desc ~= "" then
+        table.insert(lines, string.format("- `%s`: %s", ret.type, ret.desc))
+      else
+        table.insert(lines, string.format("- `%s`", ret.type))
+      end
+    end
+    table.insert(lines, "")
+  end
+
+  return table.concat(lines, "\n")
+end
+
+-- Discover modules from help._docs
+-- Returns table of {prefix = {funcs}, ...} where prefix is "" for top-level
+local function discover_modules(help_docs)
+  local modules = {}
+
+  for name, doc in pairs(help_docs) do
+    local prefix = name:match("^([^%.]+)%.") or ""
+    if not modules[prefix] then
+      modules[prefix] = {}
+    end
+    table.insert(modules[prefix], {name = name, doc = doc})
+  end
+
+  -- Sort functions within each module
+  for prefix, funcs in pairs(modules) do
+    table.sort(funcs, function(a, b)
+      local a_short = a.name:match("([^%.]+)$") or a.name
+      local b_short = b.name:match("([^%.]+)$") or b.name
+      return a_short < b_short
+    end)
+  end
+
+  return modules
+end
+
+-- Get module display name and file name
+local function module_info(prefix)
+  if prefix == "" then
+    return "cosmo", "cosmo.md"
+  else
+    return "cosmo." .. prefix, "cosmo-" .. prefix .. ".md"
+  end
+end
+
+-- Generate markdown for a module
+local function generate_module_md(module_name, funcs)
+  local lines = {"# " .. module_name, ""}
+
+  for _, item in ipairs(funcs) do
+    table.insert(lines, format_doc_md(item.name, item.doc))
+  end
+
+  return table.concat(lines, "\n")
+end
+
+-- Write a file, creating parent directories as needed
+local function write_file(path, content)
+  local dir = path:match("(.+)/[^/]+$")
+  if dir then
+    os.execute('mkdir -p "' .. dir .. '"')
+  end
+
+  local f = io.open(path, "w")
+  if not f then
+    return nil, "failed to open file: " .. path
+  end
+  f:write(content)
+  f:close()
+  return true
+end
+
+-- Get the default skill installation path
+local function default_path()
+  local home = os.getenv("HOME")
+  if not home then
+    return nil, "HOME environment variable not set"
+  end
+  return home .. "/.claude/skills"
+end
+
+-- Generate SKILL.md content with module links (dynamic)
+function skill.generate_skill_md(modules)
+  local content = SKILL_MD_HEADER
+
+  -- Sort prefixes for consistent output
+  local prefixes = {}
+  for prefix in pairs(modules) do
+    table.insert(prefixes, prefix)
+  end
+  table.sort(prefixes)
+
+  -- Add module links
+  for _, prefix in ipairs(prefixes) do
+    local display_name, filename = module_info(prefix)
+    local desc = ""
+    if prefix == "" then
+      desc = "Encoding, hashing, compression, networking"
+    elseif prefix == "unix" then
+      desc = "POSIX system calls"
+    elseif prefix == "path" then
+      desc = "Path manipulation"
+    elseif prefix == "re" then
+      desc = "Regular expressions"
+    elseif prefix == "sqlite3" then
+      desc = "SQLite database"
+    elseif prefix == "argon2" then
+      desc = "Password hashing"
+    else
+      desc = prefix .. " module"
+    end
+    content = content .. string.format("- [%s](%s) - %s\n", display_name, filename, desc)
+  end
+
+  return content
+end
+
+-- Generate all reference docs from help system
+function skill.generate_docs()
+  local help = require("cosmo.help")
+  help.load()
+
+  local modules = discover_modules(help._docs)
+  local docs = {}
+
+  for prefix, funcs in pairs(modules) do
+    local display_name, filename = module_info(prefix)
+    docs[filename] = generate_module_md(display_name, funcs)
+  end
+
+  return docs, modules
+end
+
+-- Install skill to a directory
+-- path: target directory (default: ~/.claude/skills)
+function skill.install(path)
+  if not path then
+    local default, err = default_path()
+    if not default then
+      return nil, err
+    end
+    path = default
+  elseif path:sub(-1) ~= "/" then
+    -- If path doesn't end with /, assume it's a project root
+    path = path .. "/.claude/skills"
+  end
+
+  local skill_dir = path .. "/" .. SKILL_NAME
+
+  -- Generate reference docs (also returns discovered modules)
+  local docs, modules = skill.generate_docs()
+
+  -- Generate and write SKILL.md
+  local skill_content = skill.generate_skill_md(modules)
+  local ok, err = write_file(skill_dir .. "/SKILL.md", skill_content)
+  if not ok then
+    return nil, "failed to write SKILL.md: " .. err
+  end
+
+  -- Write reference docs
+  for filename, content in pairs(docs) do
+    ok, err = write_file(skill_dir .. "/" .. filename, content)
+    if not ok then
+      return nil, "failed to write " .. filename .. ": " .. err
+    end
+  end
+
+  io.write("installed skill to: " .. skill_dir .. "\n")
+  return true
+end
+
+return skill

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -76,7 +76,8 @@ o/$(MODE)/tool/lua/lua.main.o: third_party/lua/lua.main.c
 
 TOOL_LUA_ASSETS =							\
 	o/$(MODE)/tool/lua/.lua/definitions.lua.zip.o			\
-	o/$(MODE)/tool/lua/.lua/cosmo/help/init.lua.zip.o
+	o/$(MODE)/tool/lua/.lua/cosmo/help/init.lua.zip.o		\
+	o/$(MODE)/tool/lua/.lua/cosmo/skill/init.lua.zip.o
 
 # Strip tool/lua/ prefix so files end up at /zip/.lua/
 $(TOOL_LUA_ASSETS): private ZIPOBJ_FLAGS += -C2
@@ -107,9 +108,14 @@ o/$(MODE)/tool/lua/test_help.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_help.l
 	$< tool/lua/test_help.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_skill.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_skill.lua
+	$< tool/lua/test_skill.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
-	o/$(MODE)/tool/lua/test_help.ok
+	o/$(MODE)/tool/lua/test_help.ok					\
+	o/$(MODE)/tool/lua/test_skill.ok
 
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\

--- a/tool/lua/test_skill.lua
+++ b/tool/lua/test_skill.lua
@@ -1,0 +1,42 @@
+-- test skill module
+
+local skill = require("cosmo.skill")
+
+-- Test that module loads
+assert(skill, "skill module should load")
+assert(type(skill.install) == "function", "skill.install should be a function")
+assert(type(skill.generate_skill_md) == "function", "skill.generate_skill_md should be a function")
+assert(type(skill.generate_docs) == "function", "skill.generate_docs should be a function")
+
+-- Test doc generation (also tests dynamic module discovery)
+local docs, modules = skill.generate_docs()
+assert(type(docs) == "table", "generate_docs should return docs table")
+assert(type(modules) == "table", "generate_docs should return modules table")
+
+-- Check that modules were discovered
+assert(modules[""], "should discover top-level functions (empty prefix)")
+assert(modules["unix"], "should discover unix module")
+
+-- Check that docs were generated
+assert(docs["cosmo.md"], "should generate cosmo.md")
+assert(docs["cosmo-unix.md"], "should generate cosmo-unix.md")
+
+-- Check cosmo.md has content (not empty)
+local cosmo_doc = docs["cosmo.md"]
+assert(cosmo_doc:match("# cosmo"), "cosmo.md should have module header")
+assert(#cosmo_doc > 100, "cosmo.md should have substantial content")
+
+-- Check unix docs has content
+local unix_doc = docs["cosmo-unix.md"]
+assert(unix_doc:match("# cosmo%.unix"), "cosmo-unix.md should have module header")
+assert(unix_doc:match("fork") or unix_doc:match("open"), "cosmo-unix.md should have function docs")
+
+-- Test SKILL.md generation with discovered modules
+local skill_content = skill.generate_skill_md(modules)
+assert(skill_content:match("^%-%-%-"), "SKILL.md should start with frontmatter")
+assert(skill_content:match("name: cosmo%-lua"), "SKILL.md should have correct name")
+assert(skill_content:match("whilp/cosmopolitan"), "SKILL.md should reference whilp/cosmopolitan")
+assert(skill_content:match("cosmo%.md"), "SKILL.md should reference cosmo.md")
+assert(skill_content:match("cosmo%-unix%.md"), "SKILL.md should reference cosmo-unix.md")
+
+print("all skill tests passed")


### PR DESCRIPTION
## Summary

- Adds `lua --skill [path]` command to generate and install a Claude Code skill
- The skill includes documentation generated from the help system at runtime
- Enables agents to download, update, and use cosmo-lua from whilp/cosmopolitan

## Usage

```bash
# Install to ~/.claude/skills/cosmo-lua/
lua --skill

# Install to project directory
lua --skill /path/to/project
```

## Test plan

- [ ] Build: `make MODE=dbg o/dbg/tool/lua/lua`
- [ ] Run skill test: `o/dbg/tool/lua/lua tool/lua/test_skill.lua`
- [ ] Test installation: `o/dbg/tool/lua/lua --skill /tmp/test`
- [ ] Verify generated files in `/tmp/test/.claude/skills/cosmo-lua/`