### PR TITLE
Add unix.mkdtemp and unix.mkstemp functions

### DIFF
--- a/tool/lua/test_cosmo.lua
+++ b/tool/lua/test_cosmo.lua
@@ -21,4 +21,27 @@ assert(json == '{"foo":"bar"}', "EncodeJson should produce valid JSON")
 local decoded = cosmo.DecodeJson('{"x":1}')
 assert(decoded.x == 1, "DecodeJson should parse JSON")
 
+-- test unix.mkdtemp
+local unix = cosmo.unix
+local tmpdir = unix.mkdtemp((os.getenv("TMPDIR") or "/tmp") .. "/test_XXXXXX")
+assert(tmpdir, "mkdtemp should return a path")
+assert(not tmpdir:match("XXXXXX"), "mkdtemp should replace XXXXXX")
+local stat = unix.stat(tmpdir)
+assert(stat, "mkdtemp should create a directory")
+assert(unix.S_ISDIR(stat:mode()), "mkdtemp result should be a directory")
+unix.rmdir(tmpdir)
+
+-- test unix.mkstemp
+local fd, tmpfile = unix.mkstemp((os.getenv("TMPDIR") or "/tmp") .. "/test_XXXXXX")
+assert(fd, "mkstemp should return a file descriptor")
+assert(tmpfile, "mkstemp should return a path")
+assert(not tmpfile:match("XXXXXX"), "mkstemp should replace XXXXXX")
+assert(type(fd) == "number" and fd >= 0, "mkstemp fd should be a non-negative integer")
+unix.write(fd, "test")
+unix.close(fd)
+local stat2 = unix.stat(tmpfile)
+assert(stat2, "mkstemp should create a file")
+assert(unix.S_ISREG(stat2:mode()), "mkstemp result should be a regular file")
+unix.unlink(tmpfile)
+
 print("all tests passed")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -5488,6 +5488,43 @@ function unix.mkdir(path, mode, dirfd) end
 ---@overload fun(path: string, mode?: integer): nil, error: unix.Errno
 function unix.makedirs(path, mode) end
 
+--- Creates a temporary directory with a unique name.
+---
+--- `template` must end with "XXXXXX" which will be replaced with random
+--- characters to create a unique directory name.
+---
+--- Returns the path of the created directory.
+---
+--- Example:
+---
+---     local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
+---     -- tmpdir is now something like "/tmp/myapp_a3b2c1"
+---
+---@param template string template path ending in XXXXXX
+---@return string path
+---@overload fun(template: string): nil, error: unix.Errno
+function unix.mkdtemp(template) end
+
+--- Creates a temporary file with a unique name.
+---
+--- `template` must end with "XXXXXX" which will be replaced with random
+--- characters to create a unique filename.
+---
+--- Returns both the file descriptor and the path of the created file.
+--- The file is opened for reading and writing.
+---
+--- Example:
+---
+---     local fd, path = unix.mkstemp("/tmp/myapp_XXXXXX")
+---     unix.write(fd, "hello")
+---     unix.close(fd)
+---     unix.unlink(path)
+---
+---@param template string template path ending in XXXXXX
+---@return integer fd, string path
+---@overload fun(template: string): nil, error: unix.Errno
+function unix.mkstemp(template) end
+
 --- Changes current directory to `path`.
 ---@param path string
 ---@return true


### PR DESCRIPTION
## Summary

- Add `unix.mkdtemp(template)` - creates a temporary directory, returns path
- Add `unix.mkstemp(template)` - creates a temporary file, returns fd and path
- Template must end with `XXXXXX` which gets replaced with random characters

## Example

```lua
local unix = cosmo.unix

-- Create temp directory
local tmpdir = unix.mkdtemp("/tmp/myapp_XXXXXX")
-- tmpdir is now something like "/tmp/myapp_a3b2c1"

-- Create temp file
local fd, path = unix.mkstemp("/tmp/myapp_XXXXXX")
unix.write(fd, "hello")
unix.close(fd)
unix.unlink(path)
```

## Test plan

- [x] Added tests for mkdtemp (creates directory, replaces XXXXXX, S_ISDIR)
- [x] Added tests for mkstemp (returns fd and path, replaces XXXXXX, S_ISREG)
- [x] Tests pass locally