### PR TITLE
Require submodules directly via require("cosmo.xxx")

### DIFF
--- a/tool/lua/.lua/cosmo/help/init.lua
+++ b/tool/lua/.lua/cosmo/help/init.lua
@@ -429,11 +429,18 @@ setmetatable(help, {
   end
 })
 
--- Auto-register cosmo module when help is loaded
--- (cosmo is already loaded since help is called via cosmo.help)
+-- Auto-register cosmo module and submodules when help is loaded
 local ok, cosmo = pcall(require, "cosmo")
 if ok and cosmo then
   help.register(cosmo, "cosmo")
+end
+
+-- Register submodules (they're separate requires now)
+for _, submod in ipairs({"unix", "path", "re", "argon2", "sqlite3"}) do
+  local ok, mod = pcall(require, "cosmo." .. submod)
+  if ok and mod then
+    help.register(mod, "cosmo." .. submod)
+  end
 end
 
 return help

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -199,31 +199,41 @@ static const luaL_Reg kCosmoFuncs[] = {
 };
 // clang-format on
 
+/* Register submodule in package.loaded for direct require() support */
+static void register_submodule(lua_State *L, const char *name) {
+  /* stack: cosmo, submodule */
+  lua_getfield(L, LUA_REGISTRYINDEX, LUA_LOADED_TABLE);
+  lua_pushvalue(L, -2);              /* copy submodule */
+  lua_setfield(L, -2, name);         /* package.loaded[name] = submodule */
+  lua_pop(L, 1);                     /* pop package.loaded */
+}
+
 int luaopen_cosmo(lua_State *L) {
   /* initialize fetch SSL state */
   LuaInitFetch();
 
   luaL_newlib(L, kCosmoFuncs);
 
-  /* add unix submodule */
+  /* register submodules for direct require("cosmo.xxx") */
   LuaUnix(L);
-  lua_setfield(L, -2, "unix");
+  register_submodule(L, "cosmo.unix");
+  lua_pop(L, 1);
 
-  /* add path submodule */
   LuaPath(L);
-  lua_setfield(L, -2, "path");
+  register_submodule(L, "cosmo.path");
+  lua_pop(L, 1);
 
-  /* add re submodule */
   LuaRe(L);
-  lua_setfield(L, -2, "re");
+  register_submodule(L, "cosmo.re");
+  lua_pop(L, 1);
 
-  /* add argon2 submodule */
   luaopen_argon2(L);
-  lua_setfield(L, -2, "argon2");
+  register_submodule(L, "cosmo.argon2");
+  lua_pop(L, 1);
 
-  /* add sqlite3 submodule */
   luaopen_lsqlite3(L);
-  lua_setfield(L, -2, "sqlite3");
+  register_submodule(L, "cosmo.sqlite3");
+  lua_pop(L, 1);
 
   return 1;
 }

--- a/tool/lua/test_cosmo.lua
+++ b/tool/lua/test_cosmo.lua
@@ -7,12 +7,17 @@ assert(type(cosmo.DecodeJson) == "function", "DecodeJson should be a function")
 assert(type(cosmo.EncodeJson) == "function", "EncodeJson should be a function")
 assert(type(cosmo.Sha256) == "function", "Sha256 should be a function")
 
--- test submodules exist
-assert(type(cosmo.unix) == "table", "cosmo.unix should be a table")
-assert(type(cosmo.path) == "table", "cosmo.path should be a table")
-assert(type(cosmo.re) == "table", "cosmo.re should be a table")
-assert(type(cosmo.argon2) == "table", "cosmo.argon2 should be a table")
-assert(type(cosmo.sqlite3) == "table", "cosmo.sqlite3 should be a table")
+-- test submodules via require("cosmo.xxx")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
+local re = require("cosmo.re")
+local argon2 = require("cosmo.argon2")
+local sqlite3 = require("cosmo.sqlite3")
+assert(type(unix) == "table", "require('cosmo.unix') should return a table")
+assert(type(path) == "table", "require('cosmo.path') should return a table")
+assert(type(re) == "table", "require('cosmo.re') should return a table")
+assert(type(argon2) == "table", "require('cosmo.argon2') should return a table")
+assert(type(sqlite3) == "table", "require('cosmo.sqlite3') should return a table")
 
 -- test a function actually works
 local json = cosmo.EncodeJson({foo = "bar"})
@@ -21,8 +26,7 @@ assert(json == '{"foo":"bar"}', "EncodeJson should produce valid JSON")
 local decoded = cosmo.DecodeJson('{"x":1}')
 assert(decoded.x == 1, "DecodeJson should parse JSON")
 
--- test unix.mkdtemp
-local unix = cosmo.unix
+-- test unix.mkdtemp (unix already defined above via require)
 local tmpdir = unix.mkdtemp((os.getenv("TMPDIR") or "/tmp") .. "/test_XXXXXX")
 assert(tmpdir, "mkdtemp should return a path")
 assert(not tmpdir:match("XXXXXX"), "mkdtemp should replace XXXXXX")

--- a/tool/lua/test_help.lua
+++ b/tool/lua/test_help.lua
@@ -1,6 +1,7 @@
 -- Tests for the help module parser and functionality
 
 local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
 local help = require("cosmo.help")
 
 -- Test 1: help module loaded correctly
@@ -32,8 +33,8 @@ assert(type(doc.returns) == "table", "doc.returns should be a table")
 -- Test 6: Function registration works (with cosmo. prefix)
 assert(help._funcs[cosmo.EncodeBase64] == "cosmo.EncodeBase64",
        "cosmo.EncodeBase64 should be registered")
-assert(help._funcs[cosmo.unix.fork] == "cosmo.unix.fork",
-       "cosmo.unix.fork should be registered")
+assert(help._funcs[unix.fork] == "cosmo.unix.fork",
+       "unix.fork should be registered")
 
 -- Test 7: help(func) works - finds doc via prefix stripping
 local output = {}


### PR DESCRIPTION
## Summary
- Submodules are now only accessible via direct require:
  ```lua
  local unix = require("cosmo.unix")
  local path = require("cosmo.path")
  local re = require("cosmo.re")
  local argon2 = require("cosmo.argon2")
  local sqlite3 = require("cosmo.sqlite3")
  ```
- Top-level functions remain on `require("cosmo")`
- **Breaking change**: The old `require("cosmo").unix` pattern is no longer supported

## Test plan
- [x] Run `o//tool/lua/lua.dbg tool/lua/test_cosmo.lua` - all tests pass
- [x] Run `o//tool/lua/lua.dbg tool/lua/test_help.lua` - all tests pass
- [x] Run `o//tool/lua/lua.dbg tool/lua/test_skill.lua` - all tests pass