### PR TITLE
Improve test_skill.lua with install test

### DIFF
--- a/tool/lua/.lua/cosmo/skill/init.lua
+++ b/tool/lua/.lua/cosmo/skill/init.lua
@@ -158,10 +158,11 @@ end
 
 -- Create directory and parents (like mkdir -p)
 local function mkdir_p(dir)
+  local is_absolute = dir:sub(1, 1) == "/"
   local parts = {}
   for part in dir:gmatch("[^/]+") do
     table.insert(parts, part)
-    local current = "/" .. table.concat(parts, "/")
+    local current = (is_absolute and "/" or "") .. table.concat(parts, "/")
     local stat = unix.stat(current)
     if not stat then
       local ok, err = unix.mkdir(current, 0755)

--- a/tool/lua/test_skill.lua
+++ b/tool/lua/test_skill.lua
@@ -1,6 +1,8 @@
 -- test skill module
 
 local skill = require("cosmo.skill")
+local unix = require("cosmo.unix")
+local path = require("cosmo.path")
 
 -- Test that module loads
 assert(skill, "skill module should load")
@@ -38,5 +40,22 @@ assert(skill_content:match("name: cosmo%-lua"), "SKILL.md should have correct na
 assert(skill_content:match("whilp/cosmopolitan"), "SKILL.md should reference whilp/cosmopolitan")
 assert(skill_content:match("cosmo%.md"), "SKILL.md should reference cosmo.md")
 assert(skill_content:match("cosmo%-unix%.md"), "SKILL.md should reference cosmo-unix.md")
+
+-- Test actual install to temp directory
+local tmpdir = unix.mkdtemp(path.join(os.getenv("TMPDIR") or "/tmp", "lua_skill_test_XXXXXX"))
+assert(tmpdir, "mkdtemp should create temp directory")
+local ok, err = skill.install(tmpdir .. "/")
+assert(ok, "skill.install failed: " .. (err or ""))
+
+-- Verify SKILL.md was created
+local skill_file = path.join(tmpdir, "cosmo-lua", "SKILL.md")
+local f = io.open(skill_file)
+assert(f, "SKILL.md should exist at " .. skill_file)
+local content = f:read("*a")
+f:close()
+assert(content:match("cosmo%-lua"), "SKILL.md should contain skill name")
+
+-- Cleanup
+unix.rmrf(tmpdir)
 
 print("all skill tests passed")


### PR DESCRIPTION
## Summary
- Add actual `skill.install()` test to temp directory
- Use `unix.mkdtemp` for temp directory creation
- Use `path.join` for path concatenation
- Use `unix.rmrf` for cleanup
- Fix `mkdir_p` to handle relative paths (for CI compatibility where `TMPDIR` may be relative)

## Test plan
- [x] All tests pass locally
- [x] Tests pass with relative TMPDIR (`TMPDIR=o/tmp`)