### PR TITLE
Simplify help system and make help() global

### DIFF
--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -235,5 +235,8 @@ int luaopen_cosmo(lua_State *L) {
   register_submodule(L, "cosmo.lsqlite3");
   lua_pop(L, 1);
 
+  /* make help() global for convenience */
+  (void)luaL_dostring(L, "_G.help = require('cosmo.help')");
+
   return 1;
 }

--- a/tool/lua/test_help.lua
+++ b/tool/lua/test_help.lua
@@ -8,7 +8,6 @@ local help = require("cosmo.help")
 assert(type(help) == "table", "help should be a table")
 assert(type(help.show) == "function", "help.show should be a function")
 assert(type(help.search) == "function", "help.search should be a function")
-assert(type(help.register) == "function", "help.register should be a function")
 
 -- Test 2: help is callable
 assert(type(getmetatable(help).__call) == "function", "help should be callable")
@@ -30,24 +29,18 @@ assert(doc.desc, "doc should have description")
 assert(type(doc.params) == "table", "doc.params should be a table")
 assert(type(doc.returns) == "table", "doc.returns should be a table")
 
--- Test 6: Function registration works (with cosmo. prefix)
-assert(help._funcs[cosmo.EncodeBase64] == "cosmo.EncodeBase64",
-       "cosmo.EncodeBase64 should be registered")
-assert(help._funcs[unix.fork] == "cosmo.unix.fork",
-       "unix.fork should be registered")
-
--- Test 7: help(func) works - finds doc via prefix stripping
+-- Test 6: help("name") works for string lookups
 local output = {}
 local old_print = print
 print = function(...) for i,v in ipairs({...}) do table.insert(output, tostring(v)) end end
 
-help(cosmo.EncodeBase64)
+help("EncodeBase64")
 print = old_print
 
-assert(#output > 0, "help(func) should produce output")
+assert(#output > 0, "help('name') should produce output")
 assert(output[1]:match("EncodeBase64"), "output should mention function name")
 
--- Test 8: help.search works
+-- Test 7: help.search works
 output = {}
 print = function(...) for i,v in ipairs({...}) do table.insert(output, tostring(v)) end end
 
@@ -61,13 +54,13 @@ for _, line in ipairs(output) do
 end
 assert(found_base64, "search results should include base64 functions")
 
--- Test 9: Check Fetch includes proxy info
+-- Test 8: Check Fetch includes proxy info
 local fetch_doc = help._docs["Fetch"]
 assert(fetch_doc, "Fetch should be documented")
 assert(fetch_doc.desc:match("proxy") or fetch_doc.desc:match("Proxy"),
        "Fetch docs should mention proxy support")
 
--- Test 10: Check unix module has many functions documented
+-- Test 9: Check unix module has many functions documented
 local unix_func_count = 0
 for name, doc in pairs(help._docs) do
   if name:match("^unix%.") and not doc.signature:match("%(constant%)$") then
@@ -76,7 +69,7 @@ for name, doc in pairs(help._docs) do
 end
 assert(unix_func_count >= 20, "should have at least 20 unix functions documented, got " .. unix_func_count)
 
--- Test 11: Constants are documented
+-- Test 10: Constants are documented
 assert(help._docs["unix.EEXIST"], "unix.EEXIST should be documented")
 assert(help._docs["unix.O_RDONLY"], "unix.O_RDONLY should be documented")
 local eexist_doc = help._docs["unix.EEXIST"]
@@ -84,7 +77,7 @@ assert(eexist_doc.signature:match("%(constant%)$"), "constant signature should e
 assert(eexist_doc.desc:match("File exists") or eexist_doc.desc:match("exists"),
        "EEXIST should describe file exists error")
 
--- Test 12: Unix module has many constants
+-- Test 11: Unix module has many constants
 local unix_const_count = 0
 for name, doc in pairs(help._docs) do
   if name:match("^unix%.") and doc.signature:match("%(constant%)$") then
@@ -92,5 +85,8 @@ for name, doc in pairs(help._docs) do
   end
 end
 assert(unix_const_count >= 50, "should have at least 50 unix constants documented, got " .. unix_const_count)
+
+-- Test 12: help() is available globally
+assert(_G.help == help, "help should be global")
 
 print("all help tests passed")


### PR DESCRIPTION
## Summary

- Remove `help(func)` feature that required function reference registration
- Simplify to only support string lookups: `help("Fetch")`, `help("unix.fork")`
- Make `help()` available globally for convenience (`_G.help = require('cosmo.help')`)

## Changes

- Remove `_funcs` table and `register()` function from help module
- Add special case for "cosmo" to list top-level functions
- Update overview help text to reflect simpler usage
- Add global help setup in lcosmo.c
- Update tests to remove function reference tests and add global test

## Usage

```lua
help()                 -- overview
help("cosmo")          -- list top-level functions
help("unix")           -- list module contents
help("Fetch")          -- show function documentation
help.search("base64")  -- search for matching functions
```

## Test plan

- [x] Run test_help.lua
- [x] Run test_skill.lua
- [x] Run test_cosmo.lua