### PR TITLE
Simplify skill to single SKILL.md with quick reference

### DIFF
--- a/tool/lua/.lua/cosmo/help/init.lua
+++ b/tool/lua/.lua/cosmo/help/init.lua
@@ -288,19 +288,19 @@ function help.show(what)
 Cosmo Lua Help System
 
 Modules:
-  cosmo           - Encoding, hashing, compression, networking
-  unix            - POSIX system calls
-  path            - Path manipulation
-  re              - Regular expressions
-  lsqlite3        - SQLite database
-  argon2          - Password hashing
+  cosmo            - Encoding, hashing, compression, networking
+  cosmo.unix       - POSIX system calls
+  cosmo.path       - Path manipulation
+  cosmo.re         - Regular expressions
+  cosmo.lsqlite3   - SQLite database
+  cosmo.argon2     - Password hashing
 
 Usage:
-  help()                 - This overview
-  help("cosmo")          - List top-level functions
-  help("unix")           - List module contents
-  help("Fetch")          - Show function documentation
-  help.search("base64")  - Search for matching functions
+  help()                      - This overview
+  help("cosmo")               - List top-level functions
+  help("cosmo.unix")          - List module contents
+  help("cosmo.Fetch")         - Show function documentation
+  help.search("base64")       - Search for matching functions
 ]]
     print(overview)
     return

--- a/tool/lua/test_skill.lua
+++ b/tool/lua/test_skill.lua
@@ -7,39 +7,6 @@ local path = require("cosmo.path")
 -- Test that module loads
 assert(skill, "skill module should load")
 assert(type(skill.install) == "function", "skill.install should be a function")
-assert(type(skill.generate_skill_md) == "function", "skill.generate_skill_md should be a function")
-assert(type(skill.generate_docs) == "function", "skill.generate_docs should be a function")
-
--- Test doc generation (also tests dynamic module discovery)
-local docs, modules = skill.generate_docs()
-assert(type(docs) == "table", "generate_docs should return docs table")
-assert(type(modules) == "table", "generate_docs should return modules table")
-
--- Check that modules were discovered
-assert(modules[""], "should discover top-level functions (empty prefix)")
-assert(modules["unix"], "should discover unix module")
-
--- Check that docs were generated
-assert(docs["cosmo.md"], "should generate cosmo.md")
-assert(docs["cosmo-unix.md"], "should generate cosmo-unix.md")
-
--- Check cosmo.md has content (not empty)
-local cosmo_doc = docs["cosmo.md"]
-assert(cosmo_doc:match("# cosmo"), "cosmo.md should have module header")
-assert(#cosmo_doc > 100, "cosmo.md should have substantial content")
-
--- Check unix docs has content
-local unix_doc = docs["cosmo-unix.md"]
-assert(unix_doc:match("# cosmo%.unix"), "cosmo-unix.md should have module header")
-assert(unix_doc:match("fork") or unix_doc:match("open"), "cosmo-unix.md should have function docs")
-
--- Test SKILL.md generation with discovered modules
-local skill_content = skill.generate_skill_md(modules)
-assert(skill_content:match("^%-%-%-"), "SKILL.md should start with frontmatter")
-assert(skill_content:match("name: cosmo%-lua"), "SKILL.md should have correct name")
-assert(skill_content:match("whilp/cosmopolitan"), "SKILL.md should reference whilp/cosmopolitan")
-assert(skill_content:match("cosmo%.md"), "SKILL.md should reference cosmo.md")
-assert(skill_content:match("cosmo%-unix%.md"), "SKILL.md should reference cosmo-unix.md")
 
 -- Test actual install to temp directory
 local tmpdir = unix.mkdtemp(path.join(os.getenv("TMPDIR") or "/tmp", "lua_skill_test_XXXXXX"))
@@ -53,7 +20,21 @@ local f = io.open(skill_file)
 assert(f, "SKILL.md should exist at " .. skill_file)
 local content = f:read("*a")
 f:close()
-assert(content:match("cosmo%-lua"), "SKILL.md should contain skill name")
+assert(content:match("^%-%-%-"), "SKILL.md should start with frontmatter")
+assert(content:match("name: cosmo%-lua"), "SKILL.md should have correct name")
+assert(content:match("whilp/cosmopolitan"), "SKILL.md should reference whilp/cosmopolitan")
+assert(content:match("Fetch"), "SKILL.md should document Fetch")
+assert(content:match("unix"), "SKILL.md should document unix module")
+
+-- Verify only SKILL.md was created (no other files)
+local count = 0
+for entry in unix.opendir(path.join(tmpdir, "cosmo-lua")) do
+  if entry ~= "." and entry ~= ".." then
+    count = count + 1
+    assert(entry == "SKILL.md", "only SKILL.md should be created, found: " .. entry)
+  end
+end
+assert(count == 1, "should have exactly one file, got " .. count)
 
 -- Cleanup
 unix.rmrf(tmpdir)


### PR DESCRIPTION
## Summary

- Replace dynamic per-module doc generation with a static SKILL.md
- Single file with quick reference tables organized by category
- Points to `help()` for detailed documentation

## Changes

- Rewrite skill/init.lua with static SKILL_CONTENT
- Remove `generate_docs()` and `generate_skill_md()` functions
- Update test_skill.lua to verify only SKILL.md is created

## Test plan

- [x] Run test_skill.lua - verifies only SKILL.md is created
- [x] Run test_help.lua - help system still works