### PR TITLE
Add cosmo.getopt module for CLI argument parsing

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -31,7 +31,8 @@ TOOL_LUA_LUA_MODULES =							\
 	o/$(MODE)/tool/net/ljson.o					\
 	o/$(MODE)/tool/net/lsqlite3.o					\
 	o/$(MODE)/tool/net/largon2.o					\
-	o/$(MODE)/tool/net/lfetch.o
+	o/$(MODE)/tool/net/lfetch.o					\
+	o/$(MODE)/tool/net/lgetopt.o
 
 TOOL_LUA_DIRECTDEPS =							\
 	DSP_SCALE							\
@@ -116,11 +117,16 @@ o/$(MODE)/tool/lua/test_docs.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_docs.l
 	$< tool/lua/test_docs.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_getopt.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_getopt.lua
+	$< tool/lua/test_getopt.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
 	o/$(MODE)/tool/lua/test_help.ok					\
 	o/$(MODE)/tool/lua/test_skill.ok				\
-	o/$(MODE)/tool/lua/test_docs.ok
+	o/$(MODE)/tool/lua/test_docs.ok					\
+	o/$(MODE)/tool/lua/test_getopt.ok
 
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -24,6 +24,7 @@
 #include "tool/net/lpath.h"
 #include "tool/net/ljson.h"
 #include "tool/net/lfetch.h"
+#include "tool/net/lgetopt.h"
 #include "net/http/http.h"
 #include <stdlib.h>
 #include <limits.h>
@@ -233,6 +234,10 @@ int luaopen_cosmo(lua_State *L) {
 
   luaopen_lsqlite3(L);
   register_submodule(L, "cosmo.lsqlite3");
+  lua_pop(L, 1);
+
+  LuaGetopt(L);
+  register_submodule(L, "cosmo.getopt");
   lua_pop(L, 1);
 
   /* make help() global for convenience */

--- a/tool/lua/test_getopt.lua
+++ b/tool/lua/test_getopt.lua
@@ -5,15 +5,16 @@ assert(getopt, "getopt module should exist")
 assert(type(getopt.parse) == "function", "getopt.parse should be a function")
 
 -- Test short options only
-local opts, args = getopt.parse({"-h", "-v", "-o", "out.txt", "file.txt"}, "hvo:", {})
+local opts, args, unknown = getopt.parse({"-h", "-v", "-o", "out.txt", "file.txt"}, "hvo:", {})
 assert(opts.h == true, "opts.h should be true")
 assert(opts.v == true, "opts.v should be true")
 assert(opts.o == "out.txt", "opts.o should be 'out.txt'")
 assert(args[1] == "file.txt", "first remaining arg should be 'file.txt'")
 assert(#args == 1, "should have exactly 1 remaining arg")
+assert(#unknown == 0, "should have no unknown options")
 
 -- Test long options
-opts, args = getopt.parse({"--help", "--output=foo.txt", "input.txt"}, "ho:", {
+opts, args, unknown = getopt.parse({"--help", "--output=foo.txt", "input.txt"}, "ho:", {
   {"help", "none", "h"},
   {"output", "required", "o"},
 })
@@ -22,34 +23,61 @@ assert(opts.h == true, "opts.h should also be true (from --help)")
 assert(opts.output == "foo.txt", "opts.output should be 'foo.txt'")
 assert(opts.o == "foo.txt", "opts.o should also be 'foo.txt'")
 assert(args[1] == "input.txt", "remaining arg should be 'input.txt'")
+assert(#unknown == 0, "should have no unknown options")
 
 -- Test long option with separate argument
-opts, args = getopt.parse({"--output", "bar.txt"}, "o:", {
+opts, args, unknown = getopt.parse({"--output", "bar.txt"}, "o:", {
   {"output", "required", "o"},
 })
 assert(opts.output == "bar.txt", "opts.output should be 'bar.txt'")
 assert(opts.o == "bar.txt", "opts.o should be 'bar.txt'")
+assert(#unknown == 0, "should have no unknown options")
 
 -- Test combined short options
-opts, args = getopt.parse({"-hv", "file.txt"}, "hv", {})
+opts, args, unknown = getopt.parse({"-hv", "file.txt"}, "hv", {})
 assert(opts.h == true, "opts.h should be true")
 assert(opts.v == true, "opts.v should be true")
 assert(args[1] == "file.txt", "remaining arg should be 'file.txt'")
+assert(#unknown == 0, "should have no unknown options")
 
 -- Test -- terminator
-opts, args = getopt.parse({"-h", "--", "-v", "file.txt"}, "hv", {})
+opts, args, unknown = getopt.parse({"-h", "--", "-v", "file.txt"}, "hv", {})
 assert(opts.h == true, "opts.h should be true")
 assert(opts.v == nil, "-v after -- should not be parsed as option")
 assert(args[1] == "-v", "first remaining should be '-v'")
 assert(args[2] == "file.txt", "second remaining should be 'file.txt'")
+assert(#unknown == 0, "should have no unknown options")
 
 -- Test empty args
-opts, args = getopt.parse({}, "hv", {})
+opts, args, unknown = getopt.parse({}, "hv", {})
 assert(next(opts) == nil, "opts should be empty")
 assert(#args == 0, "args should be empty")
+assert(#unknown == 0, "should have no unknown options")
 
 -- Test no longopts argument
-opts, args = getopt.parse({"-h"}, "h")
+opts, args, unknown = getopt.parse({"-h"}, "h")
 assert(opts.h == true, "opts.h should be true without longopts arg")
+assert(#unknown == 0, "should have no unknown options")
+
+-- Test unknown short option
+opts, args, unknown = getopt.parse({"-h", "-x", "-v"}, "hv", {})
+assert(opts.h == true, "opts.h should be true")
+assert(opts.v == true, "opts.v should be true")
+assert(opts.x == nil, "opts.x should be nil (unknown)")
+assert(#unknown == 1, "should have 1 unknown option")
+assert(unknown[1] == "x", "unknown[1] should be 'x'")
+
+-- Test unknown long option
+opts, args, unknown = getopt.parse({"--help", "--foo", "--verbose"}, "hv", {
+  {"help", "none", "h"},
+  {"verbose", "none", "v"},
+})
+assert(opts.help == true, "opts.help should be true")
+assert(opts.verbose == true, "opts.verbose should be true")
+assert(#unknown == 1, "should have 1 unknown option")
+
+-- Test multiple unknown options
+opts, args, unknown = getopt.parse({"-x", "-y", "-z"}, "h", {})
+assert(#unknown == 3, "should have 3 unknown options")
 
 print("PASS")

--- a/tool/lua/test_getopt.lua
+++ b/tool/lua/test_getopt.lua
@@ -1,0 +1,55 @@
+local getopt = require("cosmo.getopt")
+
+-- Test module exists
+assert(getopt, "getopt module should exist")
+assert(type(getopt.parse) == "function", "getopt.parse should be a function")
+
+-- Test short options only
+local opts, args = getopt.parse({"-h", "-v", "-o", "out.txt", "file.txt"}, "hvo:", {})
+assert(opts.h == true, "opts.h should be true")
+assert(opts.v == true, "opts.v should be true")
+assert(opts.o == "out.txt", "opts.o should be 'out.txt'")
+assert(args[1] == "file.txt", "first remaining arg should be 'file.txt'")
+assert(#args == 1, "should have exactly 1 remaining arg")
+
+-- Test long options
+opts, args = getopt.parse({"--help", "--output=foo.txt", "input.txt"}, "ho:", {
+  {"help", "none", "h"},
+  {"output", "required", "o"},
+})
+assert(opts.help == true, "opts.help should be true")
+assert(opts.h == true, "opts.h should also be true (from --help)")
+assert(opts.output == "foo.txt", "opts.output should be 'foo.txt'")
+assert(opts.o == "foo.txt", "opts.o should also be 'foo.txt'")
+assert(args[1] == "input.txt", "remaining arg should be 'input.txt'")
+
+-- Test long option with separate argument
+opts, args = getopt.parse({"--output", "bar.txt"}, "o:", {
+  {"output", "required", "o"},
+})
+assert(opts.output == "bar.txt", "opts.output should be 'bar.txt'")
+assert(opts.o == "bar.txt", "opts.o should be 'bar.txt'")
+
+-- Test combined short options
+opts, args = getopt.parse({"-hv", "file.txt"}, "hv", {})
+assert(opts.h == true, "opts.h should be true")
+assert(opts.v == true, "opts.v should be true")
+assert(args[1] == "file.txt", "remaining arg should be 'file.txt'")
+
+-- Test -- terminator
+opts, args = getopt.parse({"-h", "--", "-v", "file.txt"}, "hv", {})
+assert(opts.h == true, "opts.h should be true")
+assert(opts.v == nil, "-v after -- should not be parsed as option")
+assert(args[1] == "-v", "first remaining should be '-v'")
+assert(args[2] == "file.txt", "second remaining should be 'file.txt'")
+
+-- Test empty args
+opts, args = getopt.parse({}, "hv", {})
+assert(next(opts) == nil, "opts should be empty")
+assert(#args == 0, "args should be empty")
+
+-- Test no longopts argument
+opts, args = getopt.parse({"-h"}, "h")
+assert(opts.h == true, "opts.h should be true without longopts arg")
+
+print("PASS")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -3769,6 +3769,9 @@ function re.compile(regex, flags) end
 ---
 --- This wraps the standard GNU getopt_long(3) function for parsing command-line
 --- options with both short (-h) and long (--help) option support.
+---
+--- NOTE: This module uses global getopt state and is NOT thread-safe.
+--- Do not call from multiple threads or coroutines concurrently.
 getopt = {}
 
 --- Parse command-line arguments using getopt_long.
@@ -3785,7 +3788,7 @@ getopt = {}
 ---
 --- Example:
 ---
----     local opts, args = getopt.parse(arg, "hvo:", {
+---     local opts, args, unknown = getopt.parse(arg, "hvo:", {
 ---       {"help",    "none",     "h"},
 ---       {"verbose", "none",     "v"},
 ---       {"output",  "required", "o"},
@@ -3793,12 +3796,14 @@ getopt = {}
 ---     -- opts.h, opts.help = true if -h or --help was passed
 ---     -- opts.o, opts.output = "file.txt" if -o file.txt or --output=file.txt
 ---     -- args contains remaining non-option arguments
+---     -- unknown contains any unrecognized options
 ---
 ---@param args string[] Command-line arguments (typically `arg`)
 ---@param optstring string Short options string (e.g., "hvo:")
 ---@param longopts? table[] Long option definitions: {{name, has_arg, short}, ...}
 ---@return table opts Parsed options with both short and long names as keys
 ---@return string[] remaining Non-option arguments
+---@return string[] unknown Unrecognized options encountered during parsing
 function getopt.parse(args, optstring, longopts) end
 
 --- The path module may be used to manipulate unix paths.

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -3765,6 +3765,42 @@ function re.search(regex, text, flags) end
 ---@overload fun(regex: string, flags?: integer): nil, error: re.Errno
 function re.compile(regex, flags) end
 
+--- The getopt module provides command-line argument parsing using getopt_long.
+---
+--- This wraps the standard GNU getopt_long(3) function for parsing command-line
+--- options with both short (-h) and long (--help) option support.
+getopt = {}
+
+--- Parse command-line arguments using getopt_long.
+---
+--- The optstring uses standard getopt format:
+--- - A letter means that option takes no argument
+--- - A letter followed by : means it requires an argument
+--- - A letter followed by :: means it takes an optional argument
+---
+--- The longopts table contains entries like {"name", "has_arg", "short"}:
+--- - name: the long option name (e.g., "help" for --help)
+--- - has_arg: "none", "required", or "optional"
+--- - short: the equivalent short option character (e.g., "h")
+---
+--- Example:
+---
+---     local opts, args = getopt.parse(arg, "hvo:", {
+---       {"help",    "none",     "h"},
+---       {"verbose", "none",     "v"},
+---       {"output",  "required", "o"},
+---     })
+---     -- opts.h, opts.help = true if -h or --help was passed
+---     -- opts.o, opts.output = "file.txt" if -o file.txt or --output=file.txt
+---     -- args contains remaining non-option arguments
+---
+---@param args string[] Command-line arguments (typically `arg`)
+---@param optstring string Short options string (e.g., "hvo:")
+---@param longopts? table[] Long option definitions: {{name, has_arg, short}, ...}
+---@return table opts Parsed options with both short and long names as keys
+---@return string[] remaining Non-option arguments
+function getopt.parse(args, optstring, longopts) end
+
 --- The path module may be used to manipulate unix paths.
 ---
 --- Note that we use unix paths on Windows. For example, if you have a

--- a/tool/net/lgetopt.c
+++ b/tool/net/lgetopt.c
@@ -24,64 +24,133 @@
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lua.h"
 
-static int ParseHasArg(lua_State *L, const char *s) {
+#define MAX_ARGC    10000
+#define MAX_LONGOPTS 1000
+
+static int ParseHasArg(const char *s) {
   if (!strcmp(s, "none"))
     return no_argument;
   if (!strcmp(s, "required"))
     return required_argument;
   if (!strcmp(s, "optional"))
     return optional_argument;
-  return luaL_error(L, "has_arg must be 'none', 'required', or 'optional'");
+  return -1;
 }
 
-// getopt.parse(args, optstring, longopts) -> opts, remaining
+// getopt.parse(args, optstring, longopts) -> opts, remaining, unknown
+//
+// NOTE: This function uses global getopt state and is NOT thread-safe.
+// Do not call from multiple threads or coroutines concurrently.
 static int LuaGetoptParse(lua_State *L) {
-  int argc, nlong, opt, longidx;
+  lua_Integer argc_raw, nlong_raw;
+  int argc, nlong, opt, longidx, has_arg;
   const char *optstring;
-  char **argv;
-  struct option *longopts;
+  char **argv = NULL;
+  struct option *longopts = NULL;
   const char *longname;
   char shortopt[2];
+  int refs_idx, opts_idx, remaining_idx, unknown_idx;
 
   luaL_checktype(L, 1, LUA_TTABLE);
   optstring = luaL_checkstring(L, 2);
   if (!lua_isnoneornil(L, 3))
     luaL_checktype(L, 3, LUA_TTABLE);
 
-  // Count and allocate argv
-  argc = luaL_len(L, 1);
+  // Get sizes with bounds checking
+  argc_raw = luaL_len(L, 1);
+  if (argc_raw < 0 || argc_raw > MAX_ARGC)
+    return luaL_error(L, "args table too large (max %d)", MAX_ARGC);
+  argc = (int)argc_raw;
+
+  nlong_raw = lua_isnoneornil(L, 3) ? 0 : luaL_len(L, 3);
+  if (nlong_raw < 0 || nlong_raw > MAX_LONGOPTS)
+    return luaL_error(L, "longopts table too large (max %d)", MAX_LONGOPTS);
+  nlong = (int)nlong_raw;
+
+  // Create a table to hold references to all Lua strings we extract.
+  // This prevents the strings from being garbage collected while we
+  // hold raw pointers to them in argv[] and longopts[].name.
+  lua_newtable(L);
+  refs_idx = lua_gettop(L);
+  int ref_count = 0;
+
+  // Validate all longopts entries BEFORE allocating C memory.
+  // This ensures luaL_error won't leak memory.
+  for (int i = 0; i < nlong; i++) {
+    lua_rawgeti(L, 3, i + 1);
+    if (!lua_istable(L, -1)) {
+      return luaL_error(L, "longopt[%d] must be a table", i + 1);
+    }
+    // Check name is string
+    lua_rawgeti(L, -1, 1);
+    if (!lua_isstring(L, -1)) {
+      return luaL_error(L, "longopt[%d][1] (name) must be a string", i + 1);
+    }
+    lua_pop(L, 1);
+    // Check has_arg is valid
+    lua_rawgeti(L, -1, 2);
+    if (!lua_isstring(L, -1)) {
+      return luaL_error(L, "longopt[%d][2] (has_arg) must be a string", i + 1);
+    }
+    has_arg = ParseHasArg(lua_tostring(L, -1));
+    if (has_arg == -1) {
+      return luaL_error(L,
+          "longopt[%d][2] must be 'none', 'required', or 'optional'", i + 1);
+    }
+    lua_pop(L, 1);
+    // Check short is string if present
+    lua_rawgeti(L, -1, 3);
+    if (!lua_isnoneornil(L, -1) && !lua_isstring(L, -1)) {
+      return luaL_error(L, "longopt[%d][3] (short) must be a string or nil",
+                        i + 1);
+    }
+    lua_pop(L, 1);
+    lua_pop(L, 1);  // pop longopt entry
+  }
+
+  // Validate all args entries are strings
+  for (int i = 1; i <= argc; i++) {
+    lua_rawgeti(L, 1, i);
+    if (!lua_isstring(L, -1)) {
+      return luaL_error(L, "args[%d] must be a string", i);
+    }
+    lua_pop(L, 1);
+  }
+
+  // Now allocate C memory - all validation passed
   argv = calloc(argc + 2, sizeof(char *));
   if (!argv)
     return luaL_error(L, "out of memory");
-  argv[0] = "lua";
-  for (int i = 1; i <= argc; i++) {
-    lua_rawgeti(L, 1, i);
-    argv[i] = (char *)luaL_checkstring(L, -1);
-    lua_pop(L, 1);
-  }
-  argv[argc + 1] = NULL;
-  argc++;
 
-  // Count and allocate longopts
-  nlong = lua_isnoneornil(L, 3) ? 0 : luaL_len(L, 3);
   longopts = calloc(nlong + 1, sizeof(struct option));
   if (!longopts) {
     free(argv);
     return luaL_error(L, "out of memory");
   }
+
+  // Extract argv strings, keeping them rooted in refs table
+  argv[0] = "lua";
+  for (int i = 1; i <= argc; i++) {
+    lua_rawgeti(L, 1, i);
+    argv[i] = (char *)lua_tostring(L, -1);
+    // Store in refs table to prevent GC
+    lua_rawseti(L, refs_idx, ++ref_count);
+  }
+  argv[argc + 1] = NULL;
+  argc++;
+
+  // Extract longopts, keeping strings rooted
   for (int i = 0; i < nlong; i++) {
     lua_rawgeti(L, 3, i + 1);
-    if (!lua_istable(L, -1)) {
-      free(argv);
-      free(longopts);
-      return luaL_error(L, "longopt[%d] must be a table", i + 1);
-    }
+
     lua_rawgeti(L, -1, 1);
-    longopts[i].name = luaL_checkstring(L, -1);
-    lua_pop(L, 1);
+    longopts[i].name = lua_tostring(L, -1);
+    lua_rawseti(L, refs_idx, ++ref_count);  // keep rooted
+
     lua_rawgeti(L, -1, 2);
-    longopts[i].has_arg = ParseHasArg(L, luaL_checkstring(L, -1));
+    longopts[i].has_arg = ParseHasArg(lua_tostring(L, -1));
     lua_pop(L, 1);
+
     lua_rawgeti(L, -1, 3);
     if (lua_isstring(L, -1)) {
       const char *s = lua_tostring(L, -1);
@@ -90,8 +159,9 @@ static int LuaGetoptParse(lua_State *L) {
       longopts[i].val = 0;
     }
     lua_pop(L, 1);
+
     longopts[i].flag = NULL;
-    lua_pop(L, 1);
+    lua_pop(L, 1);  // pop longopt entry
   }
 
   // Reset getopt state
@@ -100,13 +170,27 @@ static int LuaGetoptParse(lua_State *L) {
 
   // Create result tables
   lua_newtable(L);  // opts
-  int opts_idx = lua_gettop(L);
+  opts_idx = lua_gettop(L);
+
+  lua_newtable(L);  // unknown options
+  unknown_idx = lua_gettop(L);
+  int unknown_count = 0;
 
   // Parse options
   shortopt[1] = '\0';
   while ((opt = getopt_long(argc, argv, optstring, longopts, &longidx)) != -1) {
     if (opt == '?') {
-      continue;  // Unknown option, skip
+      // Record unknown option
+      if (optopt) {
+        shortopt[0] = optopt;
+        lua_pushstring(L, shortopt);
+      } else if (argv[optind - 1]) {
+        lua_pushstring(L, argv[optind - 1]);
+      } else {
+        continue;
+      }
+      lua_rawseti(L, unknown_idx, ++unknown_count);
+      continue;
     }
     if (opt == 0) {
       // Long option with flag set
@@ -144,7 +228,7 @@ static int LuaGetoptParse(lua_State *L) {
 
   // Create remaining args table
   lua_newtable(L);
-  int remaining_idx = lua_gettop(L);
+  remaining_idx = lua_gettop(L);
   int j = 1;
   for (int i = optind; i < argc; i++) {
     lua_pushstring(L, argv[i]);
@@ -154,7 +238,12 @@ static int LuaGetoptParse(lua_State *L) {
   free(argv);
   free(longopts);
 
-  return 2;  // opts, remaining
+  // Return opts, remaining, unknown
+  lua_pushvalue(L, opts_idx);
+  lua_pushvalue(L, remaining_idx);
+  lua_pushvalue(L, unknown_idx);
+
+  return 3;
 }
 
 static const luaL_Reg kLuaGetopt[] = {

--- a/tool/net/lgetopt.c
+++ b/tool/net/lgetopt.c
@@ -1,0 +1,168 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2024 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "tool/net/lgetopt.h"
+#include "libc/mem/mem.h"
+#include "libc/str/str.h"
+#include "third_party/getopt/long1.h"
+#include "third_party/getopt/long2.h"
+#include "third_party/lua/lauxlib.h"
+#include "third_party/lua/lua.h"
+
+static int ParseHasArg(lua_State *L, const char *s) {
+  if (!strcmp(s, "none"))
+    return no_argument;
+  if (!strcmp(s, "required"))
+    return required_argument;
+  if (!strcmp(s, "optional"))
+    return optional_argument;
+  return luaL_error(L, "has_arg must be 'none', 'required', or 'optional'");
+}
+
+// getopt.parse(args, optstring, longopts) -> opts, remaining
+static int LuaGetoptParse(lua_State *L) {
+  int argc, nlong, opt, longidx;
+  const char *optstring;
+  char **argv;
+  struct option *longopts;
+  const char *longname;
+  char shortopt[2];
+
+  luaL_checktype(L, 1, LUA_TTABLE);
+  optstring = luaL_checkstring(L, 2);
+  if (!lua_isnoneornil(L, 3))
+    luaL_checktype(L, 3, LUA_TTABLE);
+
+  // Count and allocate argv
+  argc = luaL_len(L, 1);
+  argv = calloc(argc + 2, sizeof(char *));
+  if (!argv)
+    return luaL_error(L, "out of memory");
+  argv[0] = "lua";
+  for (int i = 1; i <= argc; i++) {
+    lua_rawgeti(L, 1, i);
+    argv[i] = (char *)luaL_checkstring(L, -1);
+    lua_pop(L, 1);
+  }
+  argv[argc + 1] = NULL;
+  argc++;
+
+  // Count and allocate longopts
+  nlong = lua_isnoneornil(L, 3) ? 0 : luaL_len(L, 3);
+  longopts = calloc(nlong + 1, sizeof(struct option));
+  if (!longopts) {
+    free(argv);
+    return luaL_error(L, "out of memory");
+  }
+  for (int i = 0; i < nlong; i++) {
+    lua_rawgeti(L, 3, i + 1);
+    if (!lua_istable(L, -1)) {
+      free(argv);
+      free(longopts);
+      return luaL_error(L, "longopt[%d] must be a table", i + 1);
+    }
+    lua_rawgeti(L, -1, 1);
+    longopts[i].name = luaL_checkstring(L, -1);
+    lua_pop(L, 1);
+    lua_rawgeti(L, -1, 2);
+    longopts[i].has_arg = ParseHasArg(L, luaL_checkstring(L, -1));
+    lua_pop(L, 1);
+    lua_rawgeti(L, -1, 3);
+    if (lua_isstring(L, -1)) {
+      const char *s = lua_tostring(L, -1);
+      longopts[i].val = s[0];
+    } else {
+      longopts[i].val = 0;
+    }
+    lua_pop(L, 1);
+    longopts[i].flag = NULL;
+    lua_pop(L, 1);
+  }
+
+  // Reset getopt state
+  optind = 1;
+  opterr = 0;
+
+  // Create result tables
+  lua_newtable(L);  // opts
+  int opts_idx = lua_gettop(L);
+
+  // Parse options
+  shortopt[1] = '\0';
+  while ((opt = getopt_long(argc, argv, optstring, longopts, &longidx)) != -1) {
+    if (opt == '?') {
+      continue;  // Unknown option, skip
+    }
+    if (opt == 0) {
+      // Long option with flag set
+      longname = longopts[longidx].name;
+      if (optarg) {
+        lua_pushstring(L, optarg);
+      } else {
+        lua_pushboolean(L, 1);
+      }
+      lua_setfield(L, opts_idx, longname);
+    } else {
+      // Short option (or long option returning val)
+      shortopt[0] = opt;
+      if (optarg) {
+        lua_pushstring(L, optarg);
+      } else {
+        lua_pushboolean(L, 1);
+      }
+      lua_setfield(L, opts_idx, shortopt);
+
+      // Also set long name if this came from a long option
+      for (int i = 0; i < nlong; i++) {
+        if (longopts[i].val == opt) {
+          if (optarg) {
+            lua_pushstring(L, optarg);
+          } else {
+            lua_pushboolean(L, 1);
+          }
+          lua_setfield(L, opts_idx, longopts[i].name);
+          break;
+        }
+      }
+    }
+  }
+
+  // Create remaining args table
+  lua_newtable(L);
+  int remaining_idx = lua_gettop(L);
+  int j = 1;
+  for (int i = optind; i < argc; i++) {
+    lua_pushstring(L, argv[i]);
+    lua_rawseti(L, remaining_idx, j++);
+  }
+
+  free(argv);
+  free(longopts);
+
+  return 2;  // opts, remaining
+}
+
+static const luaL_Reg kLuaGetopt[] = {
+    {"parse", LuaGetoptParse},
+    {0},
+};
+
+int LuaGetopt(lua_State *L) {
+  luaL_newlib(L, kLuaGetopt);
+  return 1;
+}

--- a/tool/net/lgetopt.h
+++ b/tool/net/lgetopt.h
@@ -1,0 +1,7 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LGETOPT_H_
+#define COSMOPOLITAN_TOOL_NET_LGETOPT_H_
+#include "third_party/lua/lauxlib.h"
+
+int LuaGetopt(lua_State *);
+
+#endif /* COSMOPOLITAN_TOOL_NET_LGETOPT_H_ */


### PR DESCRIPTION
## Summary
- Exposes the existing `third_party/getopt/` C implementation to Lua
- Wraps GNU `getopt_long(3)` for parsing command-line options
- Supports short (`-h`), long (`--help`), and combined (`-hv`) options

## Usage
```lua
local getopt = require("cosmo.getopt")

local opts, args = getopt.parse(arg, "hvo:", {
  {"help",    "none",     "h"},
  {"verbose", "none",     "v"},
  {"output",  "required", "o"},
})
```

## Test plan
- [x] `make o//tool/lua/test_getopt.ok` passes
- [x] All existing Lua tests pass (`make o//tool/lua/test`)