### PR TITLE
Add LZ4 compression support

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -32,7 +32,8 @@ TOOL_LUA_LUA_MODULES =							\
 	o/$(MODE)/tool/net/lsqlite3.o					\
 	o/$(MODE)/tool/net/largon2.o					\
 	o/$(MODE)/tool/net/lfetch.o					\
-	o/$(MODE)/tool/net/lgetopt.o
+	o/$(MODE)/tool/net/lgetopt.o					\
+	o/$(MODE)/third_party/lz4cli/lz4.o
 
 TOOL_LUA_DIRECTDEPS =							\
 	DSP_SCALE							\
@@ -59,7 +60,6 @@ TOOL_LUA_DIRECTDEPS =							\
 	THIRD_PARTY_GDTOA						\
 	THIRD_PARTY_GETOPT						\
 	THIRD_PARTY_LINENOISE						\
-	THIRD_PARTY_LZ4CLI						\
 	THIRD_PARTY_LUA							\
 	THIRD_PARTY_LUA_UNIX						\
 	THIRD_PARTY_MBEDTLS						\

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -59,6 +59,7 @@ TOOL_LUA_DIRECTDEPS =							\
 	THIRD_PARTY_GDTOA						\
 	THIRD_PARTY_GETOPT						\
 	THIRD_PARTY_LINENOISE						\
+	THIRD_PARTY_LZ4CLI						\
 	THIRD_PARTY_LUA							\
 	THIRD_PARTY_LUA_UNIX						\
 	THIRD_PARTY_MBEDTLS						\
@@ -125,12 +126,17 @@ o/$(MODE)/tool/lua/test_getopt.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_geto
 	$< tool/lua/test_getopt.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_lz4.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_lz4.lua
+	$< tool/lua/test_lz4.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
 	o/$(MODE)/tool/lua/test_help.ok					\
 	o/$(MODE)/tool/lua/test_skill.ok				\
 	o/$(MODE)/tool/lua/test_docs.ok					\
 	o/$(MODE)/tool/lua/test_getopt.ok				\
+	o/$(MODE)/tool/lua/test_lz4.ok					\
 	o/$(MODE)/tool/lua/test_strftime.ok
 
 .PHONY: o/$(MODE)/tool/lua

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -168,6 +168,8 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"IsReasonablePath", LuaIsReasonablePath},
     {"IsValidHttpToken", LuaIsValidHttpToken},
     {"Lemur64", LuaLemur64},
+    {"Lz4Compress", LuaLz4Compress},
+    {"Lz4Decompress", LuaLz4Decompress},
     {"MeasureEntropy", LuaMeasureEntropy},
     {"oct", LuaOct},
     {"ParseHost", LuaParseHost},

--- a/tool/lua/test_lz4.lua
+++ b/tool/lua/test_lz4.lua
@@ -1,0 +1,64 @@
+local cosmo = require("cosmo")
+
+-- Test Lz4Compress function exists
+assert(type(cosmo.Lz4Compress) == "function", "Lz4Compress should be a function")
+assert(type(cosmo.Lz4Decompress) == "function", "Lz4Decompress should be a function")
+
+-- Test roundtrip with simple string
+local original = "Hello, LZ4 compression!"
+local compressed = cosmo.Lz4Compress(original)
+assert(compressed ~= nil, "compression should succeed")
+assert(#compressed > 0, "compressed data should not be empty")
+
+local decompressed = cosmo.Lz4Decompress(compressed, #original)
+assert(decompressed == original, "roundtrip should preserve data, got: " .. tostring(decompressed))
+
+-- Test roundtrip with larger data
+local large = string.rep("ABCD", 1000)
+compressed = cosmo.Lz4Compress(large)
+assert(compressed ~= nil, "large compression should succeed")
+assert(#compressed < #large, "compression should reduce size for repetitive data")
+
+decompressed = cosmo.Lz4Decompress(compressed, #large)
+assert(decompressed == large, "large roundtrip should preserve data")
+
+-- Test with acceleration parameter
+compressed = cosmo.Lz4Compress(large, 1)
+assert(compressed ~= nil, "compression with acceleration=1 should succeed")
+
+local fast_compressed = cosmo.Lz4Compress(large, 10)
+assert(fast_compressed ~= nil, "compression with acceleration=10 should succeed")
+
+-- Test decompression with larger maxoutsize
+decompressed = cosmo.Lz4Decompress(compressed, #large * 2)
+assert(decompressed == large, "decompression with excess buffer should work")
+
+-- Test error on invalid decompression
+local result, err = cosmo.Lz4Decompress("not valid lz4 data", 100)
+assert(result == nil, "invalid data should return nil")
+assert(err ~= nil, "invalid data should return error message")
+
+-- Test error on zero maxoutsize
+result, err = cosmo.Lz4Decompress(compressed, 0)
+assert(result == nil, "zero maxoutsize should return nil")
+assert(err ~= nil, "zero maxoutsize should return error")
+
+-- Test error on negative maxoutsize
+result, err = cosmo.Lz4Decompress(compressed, -1)
+assert(result == nil, "negative maxoutsize should return nil")
+assert(err ~= nil, "negative maxoutsize should return error")
+
+-- Test empty string compression
+compressed = cosmo.Lz4Compress("")
+assert(compressed ~= nil, "empty string compression should succeed")
+decompressed = cosmo.Lz4Decompress(compressed, 0)
+assert(decompressed == "", "empty string roundtrip should work, got: " .. tostring(decompressed))
+
+-- Test binary data
+local binary = "\x00\x01\x02\xff\xfe\xfd"
+compressed = cosmo.Lz4Compress(binary)
+assert(compressed ~= nil, "binary compression should succeed")
+decompressed = cosmo.Lz4Decompress(compressed, #binary)
+assert(decompressed == binary, "binary roundtrip should preserve data")
+
+print("PASS")

--- a/tool/lua/test_lz4.lua
+++ b/tool/lua/test_lz4.lua
@@ -51,7 +51,7 @@ assert(err ~= nil, "negative maxoutsize should return error")
 -- Test empty string compression
 compressed = cosmo.Lz4Compress("")
 assert(compressed ~= nil, "empty string compression should succeed")
-decompressed = cosmo.Lz4Decompress(compressed, 0)
+decompressed = cosmo.Lz4Decompress(compressed, 10)  -- use small buffer, result will be ""
 assert(decompressed == "", "empty string roundtrip should work, got: " .. tostring(decompressed))
 
 -- Test binary data

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -2173,6 +2173,33 @@ function Deflate(uncompressed, level) end
 ---@overload fun(compressed: string, maxoutsize: integer): nil, error: string
 function Inflate(compressed, maxoutsize) end
 
+--- Compresses data using LZ4.
+---
+--- LZ4 is an extremely fast compression algorithm, trading compression ratio
+--- for speed. It's particularly well-suited for real-time compression scenarios.
+--- The compressed output is not compatible with other compression formats (use
+--- Deflate/Inflate for standard zlib compatibility).
+---
+---@param data string the data to compress
+---@param acceleration integer? acceleration factor (default 1). Higher values
+--- produce faster compression but with worse compression ratio. Range is 1-65537.
+---@return string compressed
+---@nodiscard
+---@overload fun(data: string, acceleration?: integer): nil, error: string
+function Lz4Compress(data, acceleration) end
+
+--- Decompresses LZ4-compressed data.
+---
+--- You must know the maximum size of the decompressed output beforehand.
+--- This is a limitation of the LZ4 format which doesn't store the original size.
+---
+---@param compressed string the LZ4-compressed data
+---@param maxoutsize integer the maximum size of the decompressed output
+---@return string decompressed
+---@nodiscard
+---@overload fun(compressed: string, maxoutsize: integer): nil, error: string
+function Lz4Decompress(compressed, maxoutsize) end
+
 --- Performs microbenchmark. Nanoseconds are computed from RDTSC tick counts,
 --- using an approximation that's measured beforehand with the
 --- unix.`clock_gettime()` function. The `ticks` result is the canonical average

--- a/tool/net/lfuncs.h
+++ b/tool/net/lfuncs.h
@@ -67,6 +67,8 @@ int LuaIsPublicIp(lua_State *);
 int LuaIsReasonablePath(lua_State *);
 int LuaIsValidHttpToken(lua_State *);
 int LuaLemur64(lua_State *);
+int LuaLz4Compress(lua_State *);
+int LuaLz4Decompress(lua_State *);
 int LuaMd5(lua_State *);
 int LuaMeasureEntropy(lua_State *);
 int LuaOct(lua_State *);


### PR DESCRIPTION
## Summary
- Exposes LZ4 fast compression via `cosmo.Lz4Compress()` and `cosmo.Lz4Decompress()`
- LZ4 provides significantly faster compression than zlib, trading off some compression ratio for speed

## Changes
- Add `LuaLz4Compress` and `LuaLz4Decompress` wrappers in `lfuncs.c`
- Register functions in `lcosmo.c` as `cosmo.Lz4Compress`/`Lz4Decompress`
- Link `lz4.o` from `third_party/lz4cli` directly (the CLI binary includes `main()`)
- Add documentation to `definitions.lua`
- Add comprehensive tests in `test_lz4.lua`

## API

```lua
-- Compress data (optional acceleration parameter, default 1)
local compressed = cosmo.Lz4Compress(data)
local fast_compressed = cosmo.Lz4Compress(data, 10)  -- faster, worse ratio

-- Decompress (must know max output size)
local original = cosmo.Lz4Decompress(compressed, expected_size)
```

## Test plan
- [x] `make o//tool/lua/test_lz4.ok` passes
- [x] All existing Lua tests still pass