### PR TITLE
Add cosmo.zip module for reading zip files

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -33,6 +33,7 @@ TOOL_LUA_LUA_MODULES =							\
 	o/$(MODE)/tool/net/largon2.o					\
 	o/$(MODE)/tool/net/lfetch.o					\
 	o/$(MODE)/tool/net/lgetopt.o					\
+	o/$(MODE)/tool/net/lzip.o					\
 	o/$(MODE)/third_party/lz4cli/lz4.o
 
 TOOL_LUA_DIRECTDEPS =							\

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -131,6 +131,10 @@ o/$(MODE)/tool/lua/test_lz4.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_lz4.lua
 	$< tool/lua/test_lz4.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_zip.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_zip.lua
+	$< tool/lua/test_zip.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
 	o/$(MODE)/tool/lua/test_help.ok					\
@@ -138,7 +142,8 @@ TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_docs.ok					\
 	o/$(MODE)/tool/lua/test_getopt.ok				\
 	o/$(MODE)/tool/lua/test_lz4.ok					\
-	o/$(MODE)/tool/lua/test_strftime.ok
+	o/$(MODE)/tool/lua/test_strftime.ok				\
+	o/$(MODE)/tool/lua/test_zip.ok
 
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -25,6 +25,7 @@
 #include "tool/net/ljson.h"
 #include "tool/net/lfetch.h"
 #include "tool/net/lgetopt.h"
+#include "tool/net/lzip.h"
 #include "net/http/http.h"
 #include <stdlib.h>
 #include <limits.h>
@@ -242,6 +243,10 @@ int luaopen_cosmo(lua_State *L) {
 
   LuaGetopt(L);
   register_submodule(L, "cosmo.getopt");
+  lua_pop(L, 1);
+
+  LuaZip(L);
+  register_submodule(L, "cosmo.zip");
   lua_pop(L, 1);
 
   /* make help() global for convenience */

--- a/tool/lua/test_zip.lua
+++ b/tool/lua/test_zip.lua
@@ -1,0 +1,97 @@
+local zip = require("cosmo.zip")
+local unix = require("cosmo.unix")
+
+-- Test module exists
+assert(zip, "zip module should exist")
+assert(type(zip.open) == "function", "zip.open should be a function")
+
+-- Create a temporary test zip file
+local tmpdir = unix.mkdtemp("/tmp/test_zip_XXXXXX")
+assert(tmpdir, "failed to create temp dir")
+local zippath = tmpdir .. "/test.zip"
+
+-- Create test content files
+local file1_content = "Hello, World!"
+local file2_content = "This is a longer text file with some content.\nIt has multiple lines.\nAnd some more text."
+
+-- Write test files
+local fd = unix.open(tmpdir .. "/file1.txt", unix.O_CREAT | unix.O_WRONLY, 0644)
+assert(fd, "failed to create file1.txt")
+unix.write(fd, file1_content)
+unix.close(fd)
+
+fd = unix.open(tmpdir .. "/file2.txt", unix.O_CREAT | unix.O_WRONLY, 0644)
+assert(fd, "failed to create file2.txt")
+unix.write(fd, file2_content)
+unix.close(fd)
+
+-- Create zip file using system zip command
+local ok = os.execute("cd " .. tmpdir .. " && zip -q test.zip file1.txt file2.txt")
+assert(ok == 0 or ok == true, "failed to create test zip file")
+
+-- Test opening the zip file
+local reader, err = zip.open(zippath)
+assert(reader, "failed to open zip: " .. tostring(err))
+assert(tostring(reader):match("zip.Reader"), "tostring should identify as zip.Reader")
+
+-- Test listing entries
+local entries = reader:list()
+assert(entries, "list should return a table")
+assert(#entries == 2, "should have 2 entries, got " .. #entries)
+
+local has_file1, has_file2 = false, false
+for _, name in ipairs(entries) do
+  if name == "file1.txt" then has_file1 = true end
+  if name == "file2.txt" then has_file2 = true end
+end
+assert(has_file1, "should have file1.txt")
+assert(has_file2, "should have file2.txt")
+
+-- Test stat
+local stat = reader:stat("file1.txt")
+assert(stat, "stat should return a table for existing file")
+assert(stat.size == #file1_content, "size should match content length")
+assert(stat.crc32, "should have crc32")
+assert(stat.method ~= nil, "should have method")
+assert(stat.mtime, "should have mtime")
+
+-- Test stat for non-existent file
+local stat2 = reader:stat("nonexistent.txt")
+assert(stat2 == nil, "stat should return nil for non-existent file")
+
+-- Test reading uncompressed content
+local content1 = reader:read("file1.txt")
+assert(content1 == file1_content, "read content should match original: got '" .. tostring(content1) .. "'")
+
+-- Test reading compressed content (file2 might be compressed if large enough)
+local content2 = reader:read("file2.txt")
+assert(content2 == file2_content, "read content should match original for file2")
+
+-- Test reading non-existent file
+local content3, err3 = reader:read("nonexistent.txt")
+assert(content3 == nil, "reading non-existent file should return nil")
+assert(err3, "should have error message")
+
+-- Test close
+reader:close()
+assert(tostring(reader):match("closed"), "tostring should indicate closed after close()")
+
+-- Test operations on closed reader
+local entries2, err2 = reader:list()
+assert(entries2 == nil, "list on closed reader should return nil")
+assert(err2, "should have error message for closed reader")
+
+-- Test opening non-existent file
+local reader2, err2 = zip.open("/nonexistent/path/to/file.zip")
+assert(reader2 == nil, "opening non-existent file should return nil")
+assert(err2, "should have error message")
+
+-- Test opening non-zip file
+local reader3, err3 = zip.open(tmpdir .. "/file1.txt")
+assert(reader3 == nil, "opening non-zip file should return nil")
+assert(err3, "should have error message for non-zip file")
+
+-- Cleanup
+os.execute("rm -rf " .. tmpdir)
+
+print("PASS")

--- a/tool/net/lzip.c
+++ b/tool/net/lzip.c
@@ -1,0 +1,380 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2024 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for        │
+│ any purpose with or without fee is hereby granted, provided that the        │
+│ above copyright notice and this permission notice appear in all copies.     │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL               │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED               │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE            │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL        │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR       │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER              │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR            │
+│ PERFORMANCE OF THIS SOFTWARE.                                               │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "tool/net/lzip.h"
+#include "libc/calls/calls.h"
+#include "libc/errno.h"
+#include "libc/mem/mem.h"
+#include "libc/str/str.h"
+#include "libc/sysv/consts/o.h"
+#include "libc/zip.h"
+#include "third_party/lua/lauxlib.h"
+#include "third_party/lua/lua.h"
+#include "third_party/zlib/zlib.h"
+
+#define LUA_ZIP_READER "zip.Reader"
+
+struct LuaZipReader {
+  int fd;
+  uint8_t *cdir;
+  int64_t cdir_size;
+  int64_t count;
+};
+
+static struct LuaZipReader *GetZipReader(lua_State *L) {
+  return luaL_checkudata(L, 1, LUA_ZIP_READER);
+}
+
+static int SysError(lua_State *L, const char *what) {
+  lua_pushnil(L);
+  lua_pushfstring(L, "%s: %s", what, strerror(errno));
+  return 2;
+}
+
+static int ZipError(lua_State *L, const char *msg) {
+  lua_pushnil(L);
+  lua_pushstring(L, msg);
+  return 2;
+}
+
+static uint8_t *FindEntry(struct LuaZipReader *z, const char *name,
+                          size_t namelen) {
+  int64_t i, got;
+  for (i = got = 0;
+       i + kZipCfileHdrMinSize <= z->cdir_size && got < z->count &&
+       i + ZIP_CFILE_HDRSIZE(z->cdir + i) <= z->cdir_size;
+       i += ZIP_CFILE_HDRSIZE(z->cdir + i), ++got) {
+    if (ZIP_CFILE_MAGIC(z->cdir + i) != kZipCfileHdrMagic)
+      return NULL;
+    const char *entry_name = ZIP_CFILE_NAME(z->cdir + i);
+    int entry_namelen = ZIP_CFILE_NAMESIZE(z->cdir + i);
+    if (entry_namelen == (int)namelen &&
+        !memcmp(entry_name, name, namelen)) {
+      return z->cdir + i;
+    }
+  }
+  return NULL;
+}
+
+// zip.open(path) -> reader, nil | nil, error
+static int LuaZipOpen(lua_State *L) {
+  const char *path;
+  struct LuaZipReader *z;
+  int64_t zsize, off, amt;
+  int64_t cnt, cdir_off, cdir_size;
+  char last64[65536];
+  ssize_t rc;
+
+  path = luaL_checkstring(L, 1);
+
+  // open file
+  int fd = open(path, O_RDONLY);
+  if (fd == -1)
+    return SysError(L, path);
+
+  // get file size
+  zsize = lseek(fd, 0, SEEK_END);
+  if (zsize == -1) {
+    close(fd);
+    return SysError(L, path);
+  }
+
+  // read last 64kb
+  if (zsize <= 65536) {
+    off = 0;
+    amt = zsize;
+  } else {
+    off = zsize - 65536;
+    amt = zsize - off;
+  }
+  if (pread(fd, last64, amt, off) != amt) {
+    close(fd);
+    return SysError(L, path);
+  }
+
+  // find end of central directory
+  cnt = -1;
+  cdir_off = 0;
+  cdir_size = 0;
+  for (int i = amt - kZipCdirHdrMinSize; i >= 0; --i) {
+    uint32_t magic = ZIP_READ32(last64 + i);
+    if (magic == kZipCdir64LocatorMagic &&
+        i + (int)kZipCdir64LocatorSize <= amt) {
+      char hdr[kZipCdir64HdrMinSize];
+      if (pread(fd, hdr, kZipCdir64HdrMinSize,
+                ZIP_LOCATE64_OFFSET(last64 + i)) == (long)kZipCdir64HdrMinSize &&
+          ZIP_READ32(hdr) == kZipCdir64HdrMagic &&
+          ZIP_CDIR64_RECORDS(hdr) == ZIP_CDIR64_RECORDSONDISK(hdr)) {
+        cnt = ZIP_CDIR64_RECORDS(hdr);
+        cdir_off = ZIP_CDIR64_OFFSET(hdr);
+        cdir_size = ZIP_CDIR64_SIZE(hdr);
+        break;
+      }
+    }
+    if (magic == kZipCdirHdrMagic && i + (int)kZipCdirHdrMinSize <= amt &&
+        ZIP_CDIR_RECORDS(last64 + i) == ZIP_CDIR_RECORDSONDISK(last64 + i) &&
+        ZIP_CDIR_OFFSET(last64 + i) != 0xffffffffu) {
+      cnt = ZIP_CDIR_RECORDS(last64 + i);
+      cdir_off = ZIP_CDIR_OFFSET(last64 + i);
+      cdir_size = ZIP_CDIR_SIZE(last64 + i);
+      break;
+    }
+  }
+
+  if (cnt < 0) {
+    close(fd);
+    return ZipError(L, "not a zip file");
+  }
+
+  // read central directory
+  uint8_t *cdir = malloc(cdir_size);
+  if (!cdir) {
+    close(fd);
+    return SysError(L, "malloc");
+  }
+  for (int64_t i = 0; i < cdir_size; i += rc) {
+    rc = pread(fd, cdir + i, cdir_size - i, cdir_off + i);
+    if (rc <= 0) {
+      free(cdir);
+      close(fd);
+      return SysError(L, path);
+    }
+  }
+
+  // create userdata
+  z = lua_newuserdatauv(L, sizeof(*z), 0);
+  luaL_setmetatable(L, LUA_ZIP_READER);
+  z->fd = fd;
+  z->cdir = cdir;
+  z->cdir_size = cdir_size;
+  z->count = cnt;
+
+  return 1;
+}
+
+// reader:close()
+static int LuaZipReaderClose(lua_State *L) {
+  struct LuaZipReader *z = GetZipReader(L);
+  if (z->fd != -1) {
+    close(z->fd);
+    z->fd = -1;
+  }
+  if (z->cdir) {
+    free(z->cdir);
+    z->cdir = NULL;
+  }
+  return 0;
+}
+
+// reader:__gc()
+static int LuaZipReaderGc(lua_State *L) {
+  return LuaZipReaderClose(L);
+}
+
+// reader:list() -> {name, ...}
+static int LuaZipReaderList(lua_State *L) {
+  struct LuaZipReader *z = GetZipReader(L);
+  if (z->fd == -1)
+    return ZipError(L, "zip reader is closed");
+
+  lua_newtable(L);
+  int idx = 1;
+  int64_t i, got;
+  for (i = got = 0;
+       i + kZipCfileHdrMinSize <= z->cdir_size && got < z->count &&
+       i + ZIP_CFILE_HDRSIZE(z->cdir + i) <= z->cdir_size;
+       i += ZIP_CFILE_HDRSIZE(z->cdir + i), ++got) {
+    if (ZIP_CFILE_MAGIC(z->cdir + i) != kZipCfileHdrMagic)
+      return ZipError(L, "corrupted central directory");
+    const char *name = ZIP_CFILE_NAME(z->cdir + i);
+    int namelen = ZIP_CFILE_NAMESIZE(z->cdir + i);
+    lua_pushlstring(L, name, namelen);
+    lua_rawseti(L, -2, idx++);
+  }
+  return 1;
+}
+
+// reader:stat(name) -> {size, compressed_size, crc32, mtime, mode, method}
+static int LuaZipReaderStat(lua_State *L) {
+  struct LuaZipReader *z = GetZipReader(L);
+  size_t namelen;
+  const char *name = luaL_checklstring(L, 2, &namelen);
+
+  if (z->fd == -1)
+    return ZipError(L, "zip reader is closed");
+
+  uint8_t *cfile = FindEntry(z, name, namelen);
+  if (!cfile) {
+    lua_pushnil(L);
+    return 1;
+  }
+
+  lua_newtable(L);
+
+  lua_pushinteger(L, GetZipCfileUncompressedSize(cfile));
+  lua_setfield(L, -2, "size");
+
+  lua_pushinteger(L, GetZipCfileCompressedSize(cfile));
+  lua_setfield(L, -2, "compressed_size");
+
+  lua_pushinteger(L, ZIP_CFILE_CRC32(cfile));
+  lua_setfield(L, -2, "crc32");
+
+  lua_pushinteger(L, GetZipCfileMode(cfile));
+  lua_setfield(L, -2, "mode");
+
+  lua_pushinteger(L, ZIP_CFILE_COMPRESSIONMETHOD(cfile));
+  lua_setfield(L, -2, "method");
+
+  struct timespec mtime, atime, ctime;
+  GetZipCfileTimestamps(cfile, &mtime, &atime, &ctime, 0);
+  lua_pushinteger(L, mtime.tv_sec);
+  lua_setfield(L, -2, "mtime");
+
+  return 1;
+}
+
+// reader:read(name) -> string | nil, error
+static int LuaZipReaderRead(lua_State *L) {
+  struct LuaZipReader *z = GetZipReader(L);
+  size_t namelen;
+  const char *name = luaL_checklstring(L, 2, &namelen);
+
+  if (z->fd == -1)
+    return ZipError(L, "zip reader is closed");
+
+  uint8_t *cfile = FindEntry(z, name, namelen);
+  if (!cfile)
+    return ZipError(L, "entry not found");
+
+  int64_t lfile_off = GetZipCfileOffset(cfile);
+  int64_t compressed_size = GetZipCfileCompressedSize(cfile);
+  int64_t uncompressed_size = GetZipCfileUncompressedSize(cfile);
+  int method = ZIP_CFILE_COMPRESSIONMETHOD(cfile);
+
+  // read local file header to get data offset
+  uint8_t lfile_hdr[kZipLfileHdrMinSize];
+  if (pread(z->fd, lfile_hdr, kZipLfileHdrMinSize, lfile_off) !=
+      kZipLfileHdrMinSize)
+    return SysError(L, "pread lfile");
+  if (ZIP_LFILE_MAGIC(lfile_hdr) != kZipLfileHdrMagic)
+    return ZipError(L, "bad local file header");
+  int64_t data_off = lfile_off + ZIP_LFILE_HDRSIZE(lfile_hdr);
+
+  // read compressed data
+  uint8_t *compressed = malloc(compressed_size ? compressed_size : 1);
+  if (!compressed)
+    return SysError(L, "malloc");
+
+  ssize_t rc;
+  for (int64_t i = 0; i < compressed_size; i += rc) {
+    rc = pread(z->fd, compressed + i, compressed_size - i, data_off + i);
+    if (rc <= 0) {
+      free(compressed);
+      return SysError(L, "pread data");
+    }
+  }
+
+  if (method == kZipCompressionNone) {
+    // stored - return as-is
+    lua_pushlstring(L, (char *)compressed, compressed_size);
+    free(compressed);
+    return 1;
+  } else if (method == kZipCompressionDeflate) {
+    // deflated - decompress
+    uint8_t *uncompressed = malloc(uncompressed_size ? uncompressed_size : 1);
+    if (!uncompressed) {
+      free(compressed);
+      return SysError(L, "malloc");
+    }
+
+    z_stream strm = {0};
+    strm.next_in = compressed;
+    strm.avail_in = compressed_size;
+    strm.next_out = uncompressed;
+    strm.avail_out = uncompressed_size;
+
+    int ret = inflateInit2(&strm, -MAX_WBITS);
+    if (ret != Z_OK) {
+      free(compressed);
+      free(uncompressed);
+      return ZipError(L, "inflateInit2 failed");
+    }
+
+    ret = inflate(&strm, Z_FINISH);
+    inflateEnd(&strm);
+    free(compressed);
+
+    if (ret != Z_STREAM_END) {
+      free(uncompressed);
+      return ZipError(L, "decompression failed");
+    }
+
+    lua_pushlstring(L, (char *)uncompressed, uncompressed_size);
+    free(uncompressed);
+    return 1;
+  } else {
+    free(compressed);
+    return ZipError(L, "unsupported compression method");
+  }
+}
+
+// reader:__tostring()
+static int LuaZipReaderTostring(lua_State *L) {
+  struct LuaZipReader *z = GetZipReader(L);
+  if (z->fd == -1) {
+    lua_pushliteral(L, "zip.Reader (closed)");
+  } else {
+    lua_pushfstring(L, "zip.Reader (%d entries)", (int)z->count);
+  }
+  return 1;
+}
+
+static const luaL_Reg kLuaZipReaderMeta[] = {
+    {"__gc", LuaZipReaderGc},
+    {"__tostring", LuaZipReaderTostring},
+    {"__close", LuaZipReaderClose},
+    {0},
+};
+
+static const luaL_Reg kLuaZipReaderMethods[] = {
+    {"close", LuaZipReaderClose},
+    {"list", LuaZipReaderList},
+    {"stat", LuaZipReaderStat},
+    {"read", LuaZipReaderRead},
+    {0},
+};
+
+static const luaL_Reg kLuaZip[] = {
+    {"open", LuaZipOpen},
+    {0},
+};
+
+int LuaZip(lua_State *L) {
+  // create zip.Reader metatable
+  luaL_newmetatable(L, LUA_ZIP_READER);
+  luaL_setfuncs(L, kLuaZipReaderMeta, 0);
+  luaL_newlibtable(L, kLuaZipReaderMethods);
+  luaL_setfuncs(L, kLuaZipReaderMethods, 0);
+  lua_setfield(L, -2, "__index");
+  lua_pop(L, 1);
+
+  // create module table
+  luaL_newlib(L, kLuaZip);
+  return 1;
+}

--- a/tool/net/lzip.c
+++ b/tool/net/lzip.c
@@ -18,6 +18,7 @@
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "tool/net/lzip.h"
 #include "libc/calls/calls.h"
+#include "libc/calls/struct/timespec.h"
 #include "libc/errno.h"
 #include "libc/mem/mem.h"
 #include "libc/str/str.h"

--- a/tool/net/lzip.h
+++ b/tool/net/lzip.h
@@ -1,0 +1,5 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LZIP_H_
+#define COSMOPOLITAN_TOOL_NET_LZIP_H_
+#include "third_party/lua/lauxlib.h"
+int LuaZip(lua_State *);
+#endif /* COSMOPOLITAN_TOOL_NET_LZIP_H_ */


### PR DESCRIPTION
## Summary

- Add read-only zip file API as `cosmo.zip` submodule
- Support for both ZIP32 and ZIP64 formats
- Automatic deflate decompression using zlib
- Proper resource cleanup via `__gc` metamethod

## API

```lua
local zip = require("cosmo.zip")

-- Open a zip file
local reader, err = zip.open("/path/to/file.zip")

-- List entries
local entries = reader:list()  -- {"file1.txt", "dir/file2.txt", ...}

-- Get file info
local stat = reader:stat("file1.txt")
-- stat.size, stat.compressed_size, stat.crc32, stat.mtime, stat.mode, stat.method

-- Read file contents (auto-decompresses)
local content = reader:read("file1.txt")

-- Close when done
reader:close()
```

## Test plan

- [ ] Run `make -j8 o//tool/lua/test_zip.ok` to verify test passes
- [ ] Test with various zip files (ZIP32, ZIP64, stored vs deflated)