### PR TITLE
Fix build: remove deleted tool/release/BUILD.mk include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,6 @@ include tool/plinko/BUILD.mk
 include test/tool/plinko/BUILD.mk
 include tool/net/BUILD.mk
 include tool/lua/BUILD.mk
-include tool/release/BUILD.mk
 include tool/viz/BUILD.mk
 include tool/BUILD.mk
 include net/turfwar/BUILD.mk


### PR DESCRIPTION
## Summary

Fixes build dependency loop caused by including a non-existent `tool/release/BUILD.mk` file.

## Problem

The Makefile includes `tool/release/BUILD.mk`, but this file doesn't exist in the repository, causing the build system to repeatedly delete and regenerate the dependency file.

## Solution

Remove the include statement for the missing file.

## Files changed

- `Makefile` - Remove `include tool/release/BUILD.mk`