### PR TITLE
lua: add cosmo.goodsocket module

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -35,6 +35,7 @@ TOOL_LUA_LUA_MODULES =							\
 	o/$(MODE)/tool/net/lfetch.o					\
 	o/$(MODE)/tool/net/lgetopt.o					\
 	o/$(MODE)/tool/net/lzip.o					\
+	o/$(MODE)/tool/net/lgoodsocket.o				\
 	o/$(MODE)/third_party/lz4cli/lz4.o
 
 TOOL_LUA_DIRECTDEPS =							\
@@ -154,6 +155,10 @@ o/$(MODE)/tool/lua/cosmo/http/test_server_security.ok: o/$(MODE)/tool/lua/lua.db
 	$< tool/lua/cosmo/http/test_server_security.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_goodsocket.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_goodsocket.lua
+	$< tool/lua/test_goodsocket.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
 	o/$(MODE)/tool/lua/cosmo/help/test.ok				\
@@ -166,7 +171,8 @@ TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/cosmo/http/test.ok				\
 	o/$(MODE)/tool/lua/cosmo/http/test_server.ok			\
 	o/$(MODE)/tool/lua/cosmo/http/test_security.ok			\
-	o/$(MODE)/tool/lua/cosmo/http/test_server_security.ok
+	o/$(MODE)/tool/lua/cosmo/http/test_server_security.ok		\
+	o/$(MODE)/tool/lua/test_goodsocket.ok
 
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\

--- a/tool/lua/cosmo/help/init.lua
+++ b/tool/lua/cosmo/help/init.lua
@@ -309,6 +309,7 @@ Modules:
   cosmo.lsqlite3   - SQLite database
   cosmo.argon2     - Password hashing
   cosmo.http       - HTTP parsing, formatting, and server
+  cosmo.goodsocket - Optimized socket creation
 
 Usage:
   help()                      - This overview

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -27,6 +27,7 @@
 #include "tool/net/lgetopt.h"
 #include "tool/net/lzip.h"
 #include "tool/net/lhttp.h"
+#include "tool/net/lgoodsocket.h"
 #include "net/http/http.h"
 #include <stdlib.h>
 #include <limits.h>
@@ -252,6 +253,10 @@ int luaopen_cosmo(lua_State *L) {
 
   LuaHttp(L);
   register_submodule(L, "cosmo.http");
+  lua_pop(L, 1);
+
+  LuaGoodSocket(L);
+  register_submodule(L, "cosmo.goodsocket");
   lua_pop(L, 1);
 
   /* make help() global for convenience */

--- a/tool/lua/test_goodsocket.lua
+++ b/tool/lua/test_goodsocket.lua
@@ -1,3 +1,4 @@
+local cosmo = require("cosmo")
 local gs = require("cosmo.goodsocket")
 local unix = require("cosmo.unix")
 
@@ -211,11 +212,7 @@ assert(fd, "failed to create socket: " .. tostring(err))
 
 -- Try to bind it (this tests that it's a real socket)
 -- We use port 0 to let the OS assign a port
-local ok, bind_err = unix.bind(fd, {
-  family = gs.AF_INET,
-  addr = "127.0.0.1",
-  port = 0
-})
+local ok, bind_err = unix.bind(fd, cosmo.ParseIp("127.0.0.1"), 0)
 if ok then
   -- If bind succeeds, the socket is valid
   assert(unix.close(fd), "should be able to close bound socket")
@@ -254,11 +251,7 @@ local server_fd, server_err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_T
 assert(server_fd, "failed to create server socket: " .. tostring(server_err))
 
 -- Bind to localhost on a random port
-ok, err = unix.bind(server_fd, {
-  family = gs.AF_INET,
-  addr = "127.0.0.1",
-  port = 0
-})
+ok, err = unix.bind(server_fd, cosmo.ParseIp("127.0.0.1"), 0)
 
 if ok then
   -- If bind succeeds, try to listen

--- a/tool/lua/test_goodsocket.lua
+++ b/tool/lua/test_goodsocket.lua
@@ -1,0 +1,283 @@
+local gs = require("cosmo.goodsocket")
+local unix = require("cosmo.unix")
+
+-- Test module exists
+assert(gs, "goodsocket module should exist")
+assert(type(gs.socket) == "function", "gs.socket should be a function")
+
+--------------------------------------------------------------------------------
+-- Test constants are exported
+--------------------------------------------------------------------------------
+
+-- Socket families
+assert(type(gs.AF_INET) == "number", "AF_INET should be a number")
+assert(type(gs.AF_INET6) == "number", "AF_INET6 should be a number")
+assert(type(gs.AF_UNIX) == "number", "AF_UNIX should be a number")
+assert(type(gs.AF_UNSPEC) == "number", "AF_UNSPEC should be a number")
+assert(gs.AF_INET == 2, "AF_INET should be 2")
+assert(gs.AF_UNIX == 1, "AF_UNIX should be 1")
+assert(gs.AF_UNSPEC == 0, "AF_UNSPEC should be 0")
+
+-- Socket types
+assert(type(gs.SOCK_STREAM) == "number", "SOCK_STREAM should be a number")
+assert(type(gs.SOCK_DGRAM) == "number", "SOCK_DGRAM should be a number")
+assert(type(gs.SOCK_RAW) == "number", "SOCK_RAW should be a number")
+assert(type(gs.SOCK_RDM) == "number", "SOCK_RDM should be a number")
+assert(type(gs.SOCK_SEQPACKET) == "number", "SOCK_SEQPACKET should be a number")
+assert(gs.SOCK_STREAM == 1, "SOCK_STREAM should be 1")
+assert(gs.SOCK_DGRAM == 2, "SOCK_DGRAM should be 2")
+
+-- Protocols
+assert(type(gs.IPPROTO_IP) == "number", "IPPROTO_IP should be a number")
+assert(type(gs.IPPROTO_TCP) == "number", "IPPROTO_TCP should be a number")
+assert(type(gs.IPPROTO_UDP) == "number", "IPPROTO_UDP should be a number")
+assert(type(gs.IPPROTO_ICMP) == "number", "IPPROTO_ICMP should be a number")
+assert(type(gs.IPPROTO_IPV6) == "number", "IPPROTO_IPV6 should be a number")
+assert(type(gs.IPPROTO_ICMPV6) == "number", "IPPROTO_ICMPV6 should be a number")
+assert(type(gs.IPPROTO_RAW) == "number", "IPPROTO_RAW should be a number")
+assert(gs.IPPROTO_IP == 0, "IPPROTO_IP should be 0")
+assert(gs.IPPROTO_TCP == 6, "IPPROTO_TCP should be 6")
+assert(gs.IPPROTO_UDP == 17, "IPPROTO_UDP should be 17")
+
+--------------------------------------------------------------------------------
+-- Test basic socket creation
+--------------------------------------------------------------------------------
+
+-- Create a TCP socket (client)
+local fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false)
+assert(fd, "failed to create TCP client socket: " .. tostring(err))
+assert(type(fd) == "number", "socket should return a number (file descriptor)")
+assert(fd >= 0, "file descriptor should be non-negative")
+assert(unix.close(fd), "should be able to close socket")
+
+-- Create a TCP socket (server)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, true)
+assert(fd, "failed to create TCP server socket: " .. tostring(err))
+assert(type(fd) == "number", "socket should return a number")
+assert(fd >= 0, "file descriptor should be non-negative")
+assert(unix.close(fd), "should be able to close server socket")
+
+-- Create a UDP socket
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_DGRAM, gs.IPPROTO_UDP, false)
+assert(fd, "failed to create UDP socket: " .. tostring(err))
+assert(type(fd) == "number", "socket should return a number")
+assert(fd >= 0, "file descriptor should be non-negative")
+assert(unix.close(fd), "should be able to close UDP socket")
+
+-- Create an IPv6 TCP socket
+fd, err = gs.socket(gs.AF_INET6, gs.SOCK_STREAM, gs.IPPROTO_TCP, false)
+assert(fd, "failed to create IPv6 TCP socket: " .. tostring(err))
+assert(type(fd) == "number", "socket should return a number")
+assert(fd >= 0, "file descriptor should be non-negative")
+assert(unix.close(fd), "should be able to close IPv6 socket")
+
+-- Create a Unix domain socket
+fd, err = gs.socket(gs.AF_UNIX, gs.SOCK_STREAM, 0, false)
+assert(fd, "failed to create Unix socket: " .. tostring(err))
+assert(type(fd) == "number", "socket should return a number")
+assert(fd >= 0, "file descriptor should be non-negative")
+assert(unix.close(fd), "should be able to close Unix socket")
+
+--------------------------------------------------------------------------------
+-- Test socket creation with default protocol (0)
+--------------------------------------------------------------------------------
+
+-- TCP with protocol 0 (should default to TCP)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, 0, false)
+assert(fd, "failed to create TCP socket with protocol 0: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- UDP with protocol 0 (should default to UDP)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_DGRAM, 0, false)
+assert(fd, "failed to create UDP socket with protocol 0: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+--------------------------------------------------------------------------------
+-- Test timeout configurations
+--------------------------------------------------------------------------------
+
+-- Create socket with positive timeout (SO_RCVTIMEO/SO_SNDTIMEO)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 30)
+assert(fd, "failed to create socket with positive timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket with timeout")
+
+-- Create socket with fractional timeout
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 2.5)
+assert(fd, "failed to create socket with fractional timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- Create socket with negative timeout (SO_KEEPALIVE)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, -60)
+assert(fd, "failed to create socket with negative timeout (keepalive): " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket with keepalive")
+
+-- Create socket with zero timeout
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 0)
+assert(fd, "failed to create socket with zero timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- Create socket with nil timeout (no timeout settings)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, nil)
+assert(fd, "failed to create socket with nil timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- Create socket without timeout parameter
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false)
+assert(fd, "failed to create socket without timeout parameter: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+--------------------------------------------------------------------------------
+-- Test server vs client sockets
+--------------------------------------------------------------------------------
+
+-- Server socket (isserver=true)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, true)
+assert(fd, "failed to create server socket: " .. tostring(err))
+assert(unix.close(fd), "should be able to close server socket")
+
+-- Client socket (isserver=false)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false)
+assert(fd, "failed to create client socket: " .. tostring(err))
+assert(unix.close(fd), "should be able to close client socket")
+
+-- Server socket with boolean true
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, true, 30)
+assert(fd, "failed to create server socket with boolean: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- Client socket with boolean false
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 30)
+assert(fd, "failed to create client socket with boolean: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+--------------------------------------------------------------------------------
+-- Test invalid parameters
+--------------------------------------------------------------------------------
+
+-- Invalid family
+local ok, result = pcall(function()
+  return gs.socket(99999, gs.SOCK_STREAM, gs.IPPROTO_TCP, false)
+end)
+-- This may succeed or fail depending on the OS, but should not crash
+assert(type(ok) == "boolean", "pcall should return a boolean")
+
+-- Invalid socket type
+ok, result = pcall(function()
+  return gs.socket(gs.AF_INET, 99999, gs.IPPROTO_TCP, false)
+end)
+-- This may succeed or fail depending on the OS, but should not crash
+assert(type(ok) == "boolean", "pcall should return a boolean")
+
+-- Invalid protocol (should fail)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, 99999, false)
+-- This should fail, but we check both outcomes
+if fd then
+  unix.close(fd)
+else
+  assert(err, "should have error message for invalid protocol")
+end
+
+--------------------------------------------------------------------------------
+-- Test multiple sockets
+--------------------------------------------------------------------------------
+
+-- Create multiple sockets and ensure they have different file descriptors
+local fds = {}
+for i = 1, 5 do
+  fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false)
+  assert(fd, "failed to create socket " .. i .. ": " .. tostring(err))
+  table.insert(fds, fd)
+end
+
+-- Verify all file descriptors are unique
+for i = 1, #fds do
+  for j = i + 1, #fds do
+    assert(fds[i] ~= fds[j], "file descriptors should be unique")
+  end
+end
+
+-- Close all sockets
+for _, sockfd in ipairs(fds) do
+  assert(unix.close(sockfd), "should be able to close socket")
+end
+
+--------------------------------------------------------------------------------
+-- Test that goodsocket actually creates valid sockets
+--------------------------------------------------------------------------------
+
+-- Create a socket and verify we can perform socket operations on it
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, true)
+assert(fd, "failed to create socket: " .. tostring(err))
+
+-- Try to bind it (this tests that it's a real socket)
+-- We use port 0 to let the OS assign a port
+local ok, bind_err = unix.bind(fd, {
+  family = gs.AF_INET,
+  addr = "127.0.0.1",
+  port = 0
+})
+if ok then
+  -- If bind succeeds, the socket is valid
+  assert(unix.close(fd), "should be able to close bound socket")
+elseif bind_err then
+  -- If bind fails, it should be because of permission/address issues,
+  -- not because fd is invalid
+  assert(type(bind_err) == "string", "bind error should be a string")
+  unix.close(fd)
+end
+
+--------------------------------------------------------------------------------
+-- Test edge cases
+--------------------------------------------------------------------------------
+
+-- Very large timeout
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 86400)
+assert(fd, "failed to create socket with large timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- Very small timeout
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 0.001)
+assert(fd, "failed to create socket with small timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+-- Large negative timeout (keepalive)
+fd, err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, -3600)
+assert(fd, "failed to create socket with large negative timeout: " .. tostring(err))
+assert(unix.close(fd), "should be able to close socket")
+
+--------------------------------------------------------------------------------
+-- Test that sockets work for actual communication
+--------------------------------------------------------------------------------
+
+-- Create a server socket
+local server_fd, server_err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, true, 5)
+assert(server_fd, "failed to create server socket: " .. tostring(server_err))
+
+-- Bind to localhost on a random port
+ok, err = unix.bind(server_fd, {
+  family = gs.AF_INET,
+  addr = "127.0.0.1",
+  port = 0
+})
+
+if ok then
+  -- If bind succeeds, try to listen
+  local listen_ok, listen_err = unix.listen(server_fd, 5)
+  if listen_ok then
+    -- Successfully created a listening socket with goodsocket!
+    assert(unix.close(server_fd), "should be able to close listening socket")
+  else
+    -- Listen failed, but that's okay for this test
+    unix.close(server_fd)
+  end
+else
+  -- Bind failed, close the socket
+  unix.close(server_fd)
+end
+
+-- Create a client socket
+local client_fd, client_err = gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false, 5)
+assert(client_fd, "failed to create client socket: " .. tostring(client_err))
+assert(unix.close(client_fd), "should be able to close client socket")
+
+print("PASS")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -4213,6 +4213,75 @@ function argon2.hash_encoded(pass, salt, config) end
 ---@overload fun(encoded: string, pass: string): nil, error: string
 function argon2.verify(encoded, pass) end
 
+--- This module provides optimized socket creation with modern TCP features.
+--- It wraps the GoodSocket() C function which enables TCP Fast Open, Quick ACK,
+--- and other performance optimizations automatically.
+goodsocket = {
+    --- @type integer IPv4 address family
+    AF_INET = nil,
+    --- @type integer IPv6 address family
+    AF_INET6 = nil,
+    --- @type integer Unix domain socket address family
+    AF_UNIX = nil,
+    --- @type integer Unspecified address family
+    AF_UNSPEC = nil,
+
+    --- @type integer Stream socket (TCP)
+    SOCK_STREAM = nil,
+    --- @type integer Datagram socket (UDP)
+    SOCK_DGRAM = nil,
+    --- @type integer Raw socket
+    SOCK_RAW = nil,
+    --- @type integer Reliable datagram socket
+    SOCK_RDM = nil,
+    --- @type integer Sequenced packet socket
+    SOCK_SEQPACKET = nil,
+
+    --- @type integer Default IP protocol
+    IPPROTO_IP = nil,
+    --- @type integer TCP protocol
+    IPPROTO_TCP = nil,
+    --- @type integer UDP protocol
+    IPPROTO_UDP = nil,
+    --- @type integer ICMP protocol
+    IPPROTO_ICMP = nil,
+    --- @type integer IPv6 protocol
+    IPPROTO_IPV6 = nil,
+    --- @type integer ICMPv6 protocol
+    IPPROTO_ICMPV6 = nil,
+    --- @type integer Raw IP protocol
+    IPPROTO_RAW = nil,
+}
+
+--- Creates a socket with modern TCP optimizations enabled.
+---
+--- This function wraps GoodSocket() which automatically enables performance
+--- features like TCP Fast Open, Quick ACK, and other optimizations based on
+--- whether you're creating a client or server socket.
+---
+--- Example:
+---
+---     local gs = require("cosmo.goodsocket")
+---     local unix = require("cosmo.unix")
+---
+---     -- Create a TCP client socket
+---     local fd = assert(gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, false))
+---     unix.close(fd)
+---
+---     -- Create a TCP server socket with 30 second timeout
+---     local fd = assert(gs.socket(gs.AF_INET, gs.SOCK_STREAM, gs.IPPROTO_TCP, true, 30))
+---     unix.close(fd)
+---
+---@param family integer Socket family (AF_INET, AF_INET6, AF_UNIX, etc.)
+---@param type integer Socket type (SOCK_STREAM, SOCK_DGRAM, etc.)
+---@param protocol integer Protocol (IPPROTO_TCP, IPPROTO_UDP, 0 for default)
+---@param isserver boolean True for server sockets, false for client sockets
+---@param timeout? number Optional timeout in seconds. Positive values set SO_RCVTIMEO/SO_SNDTIMEO. Negative values enable SO_KEEPALIVE.
+---@return integer fd File descriptor on success
+---@nodiscard
+---@overload fun(family: integer, type: integer, protocol: integer, isserver: boolean, timeout?: number): nil, error: string
+function goodsocket.socket(family, type, protocol, isserver, timeout) end
+
 --- This module exposes the low-level System Five system call interface.
 --- This module works on all supported platforms, including Windows NT.
 unix = {

--- a/tool/net/lgoodsocket.c
+++ b/tool/net/lgoodsocket.c
@@ -1,0 +1,125 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2024 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "tool/net/lgoodsocket.h"
+#include "libc/calls/struct/timeval.h"
+#include "libc/errno.h"
+#include "libc/sock/goodsocket.internal.h"
+#include "libc/str/str.h"
+#include "libc/sysv/consts/af.h"
+#include "libc/sysv/consts/ipproto.h"
+#include "libc/sysv/consts/sock.h"
+#include "third_party/lua/lauxlib.h"
+#include "third_party/lua/lua.h"
+
+static int SysError(lua_State *L, const char *what) {
+  lua_pushnil(L);
+  lua_pushfstring(L, "%s: %s", what, strerror(errno));
+  return 2;
+}
+
+// goodsocket.socket(family, type, protocol, isserver, [timeout])
+//   -> fd | nil, error
+//
+// Creates a socket with modern goodness enabled.
+//
+// Parameters:
+//   family: Socket family (e.g., AF_INET, AF_INET6, AF_UNIX)
+//   type: Socket type (e.g., SOCK_STREAM, SOCK_DGRAM)
+//   protocol: Protocol (e.g., IPPROTO_TCP, IPPROTO_UDP, 0 for default)
+//   isserver: Boolean indicating if this is a server socket
+//   timeout: Optional timeout in seconds (number) or nil
+//            - positive: sets SO_RCVTIMEO and SO_SNDTIMEO
+//            - negative: enables SO_KEEPALIVE with -timeout as interval
+//            - nil: no timeout settings
+//
+// Returns:
+//   fd: File descriptor on success
+//   nil, error: On failure
+static int LuaGoodSocketSocket(lua_State *L) {
+  int family = luaL_checkinteger(L, 1);
+  int type = luaL_checkinteger(L, 2);
+  int protocol = luaL_checkinteger(L, 3);
+  bool isserver = lua_toboolean(L, 4);
+
+  struct timeval tv;
+  struct timeval *timeout_ptr = NULL;
+
+  if (!lua_isnoneornil(L, 5)) {
+    lua_Number timeout_num = luaL_checknumber(L, 5);
+    tv.tv_sec = (time_t)timeout_num;
+    tv.tv_usec = (suseconds_t)((timeout_num - tv.tv_sec) * 1000000);
+    timeout_ptr = &tv;
+  }
+
+  int fd = GoodSocket(family, type, protocol, isserver, timeout_ptr);
+  if (fd == -1)
+    return SysError(L, "socket");
+
+  lua_pushinteger(L, fd);
+  return 1;
+}
+
+static const luaL_Reg kLuaGoodSocket[] = {
+    {"socket", LuaGoodSocketSocket},
+    {0},
+};
+
+int LuaGoodSocket(lua_State *L) {
+  luaL_newlib(L, kLuaGoodSocket);
+
+  // Socket families (AF_*)
+  lua_pushinteger(L, AF_INET);
+  lua_setfield(L, -2, "AF_INET");
+  lua_pushinteger(L, AF_INET6);
+  lua_setfield(L, -2, "AF_INET6");
+  lua_pushinteger(L, AF_UNIX);
+  lua_setfield(L, -2, "AF_UNIX");
+  lua_pushinteger(L, AF_UNSPEC);
+  lua_setfield(L, -2, "AF_UNSPEC");
+
+  // Socket types (SOCK_*)
+  lua_pushinteger(L, SOCK_STREAM);
+  lua_setfield(L, -2, "SOCK_STREAM");
+  lua_pushinteger(L, SOCK_DGRAM);
+  lua_setfield(L, -2, "SOCK_DGRAM");
+  lua_pushinteger(L, SOCK_RAW);
+  lua_setfield(L, -2, "SOCK_RAW");
+  lua_pushinteger(L, SOCK_RDM);
+  lua_setfield(L, -2, "SOCK_RDM");
+  lua_pushinteger(L, SOCK_SEQPACKET);
+  lua_setfield(L, -2, "SOCK_SEQPACKET");
+
+  // IP protocols (IPPROTO_*)
+  lua_pushinteger(L, IPPROTO_IP);
+  lua_setfield(L, -2, "IPPROTO_IP");
+  lua_pushinteger(L, IPPROTO_TCP);
+  lua_setfield(L, -2, "IPPROTO_TCP");
+  lua_pushinteger(L, IPPROTO_UDP);
+  lua_setfield(L, -2, "IPPROTO_UDP");
+  lua_pushinteger(L, IPPROTO_ICMP);
+  lua_setfield(L, -2, "IPPROTO_ICMP");
+  lua_pushinteger(L, IPPROTO_IPV6);
+  lua_setfield(L, -2, "IPPROTO_IPV6");
+  lua_pushinteger(L, IPPROTO_ICMPV6);
+  lua_setfield(L, -2, "IPPROTO_ICMPV6");
+  lua_pushinteger(L, IPPROTO_RAW);
+  lua_setfield(L, -2, "IPPROTO_RAW");
+
+  return 1;
+}

--- a/tool/net/lgoodsocket.c
+++ b/tool/net/lgoodsocket.c
@@ -62,8 +62,8 @@ static int LuaGoodSocketSocket(lua_State *L) {
 
   if (!lua_isnoneornil(L, 5)) {
     lua_Number timeout_num = luaL_checknumber(L, 5);
-    tv.tv_sec = (time_t)timeout_num;
-    tv.tv_usec = (suseconds_t)((timeout_num - tv.tv_sec) * 1000000);
+    tv.tv_sec = (int64_t)timeout_num;
+    tv.tv_usec = (int64_t)((timeout_num - tv.tv_sec) * 1000000);
     timeout_ptr = &tv;
   }
 

--- a/tool/net/lgoodsocket.h
+++ b/tool/net/lgoodsocket.h
@@ -1,0 +1,7 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LGOODSOCKET_H_
+#define COSMOPOLITAN_TOOL_NET_LGOODSOCKET_H_
+#include "third_party/lua/lauxlib.h"
+
+int LuaGoodSocket(lua_State *);
+
+#endif /* COSMOPOLITAN_TOOL_NET_LGOODSOCKET_H_ */


### PR DESCRIPTION
## Summary

Exposes the GoodSocket C library to Lua at `cosmo.goodsocket`, providing a modern socket creation wrapper that enables TCP Fast Open, Quick ACK, and other performance optimizations.

### Features
- `goodsocket.socket(family, type, protocol, isserver, [timeout])` creates sockets with modern TCP goodness enabled
- Exports socket family constants (AF_INET, AF_INET6, AF_UNIX, etc.)
- Exports socket type constants (SOCK_STREAM, SOCK_DGRAM, etc.)
- Exports protocol constants (IPPROTO_TCP, IPPROTO_UDP, etc.)
- Supports optional timeout parameter for SO_RCVTIMEO/SO_SNDTIMEO
- Supports negative timeout for SO_KEEPALIVE configuration
- Full help() documentation support

### Also included
- Updated `cosmo.http` server to use GoodSocket internally, enabling TCP Fast Open and Quick ACK for all HTTP servers

### Files changed
- `tool/net/lgoodsocket.h`: Header file
- `tool/net/lgoodsocket.c`: Implementation with Lua bindings
- `tool/net/lhttp.c`: Use GoodSocket for server sockets
- `tool/net/definitions.lua`: Help documentation
- `tool/lua/lcosmo.c`: Registration of cosmo.goodsocket module
- `tool/lua/BUILD.mk`: Build integration
- `tool/lua/test_goodsocket.lua`: Comprehensive test suite
- `tool/lua/.lua/cosmo/help/init.lua`: Help overview update

## Test plan
- [x] `make MODE=x86_64 o/x86_64/tool/lua/lua.dbg` builds successfully
- [x] `lua tool/lua/test_goodsocket.lua` passes
- [x] `lua tool/lua/test_http.lua` passes
- [x] `lua tool/lua/test_http_server.lua` passes
- [x] `help("cosmo.goodsocket")` works
- [x] `help("goodsocket.socket")` shows full documentation