### PR TITLE
build: update cosmocc gcc to fix gvisor segfault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,10 @@ export MODE
 export SOURCE_DATE_EPOCH
 export TMPDIR
 
-COSMOCC = .cosmocc/3.9.2
+COSMOCC = .cosmocc/2025.12.30-c15a7c08f
 BOOTSTRAP = $(COSMOCC)/bin
 TOOLCHAIN = $(COSMOCC)/bin/$(ARCH)-linux-cosmo-
-DOWNLOAD := $(shell build/download-cosmocc.sh $(COSMOCC) 3.9.2 f4ff13af65fcd309f3f1cfd04275996fb7f72a4897726628a8c9cf732e850193)
+DOWNLOAD := $(shell build/download-cosmocc.sh $(COSMOCC) 2025.12.30-c15a7c08f 5f75fb0be8def50c99b6f01e3c63df58658562f9161213ec70a2c86140a6b791)
 
 IGNORE := $(shell $(MKDIR) $(TMPDIR))
 

--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,10 @@ export MODE
 export SOURCE_DATE_EPOCH
 export TMPDIR
 
-COSMOCC = .cosmocc/2025.12.30-c15a7c08f
+COSMOCC = .cosmocc/3.9.2
 BOOTSTRAP = $(COSMOCC)/bin
 TOOLCHAIN = $(COSMOCC)/bin/$(ARCH)-linux-cosmo-
-DOWNLOAD := $(shell build/download-cosmocc.sh $(COSMOCC) 2025.12.30-c15a7c08f 5f75fb0be8def50c99b6f01e3c63df58658562f9161213ec70a2c86140a6b791)
+DOWNLOAD := $(shell build/download-cosmocc.sh $(COSMOCC) 3.9.2 f4ff13af65fcd309f3f1cfd04275996fb7f72a4897726628a8c9cf732e850193)
 
 IGNORE := $(shell $(MKDIR) $(TMPDIR))
 

--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -283,9 +283,9 @@ fetch() {
 OLD=$PWD
 cd "$OUTDIR/"
 if [ ! -x bin/x86_64-linux-cosmo-gcc ]; then
-  fetch https://github.com/ahgamut/superconfigure/releases/download/z0.0.60/aarch64-gcc.zip 6a07f915ec0296cd33b3142e75c00ed1a7072c75d92c82a0c0b5f5df2cff0dd2 &
-  fetch https://github.com/ahgamut/superconfigure/releases/download/z0.0.60/x86_64-gcc.zip cbb1659c56a0a4f95a71f59f94693515000d3dd53f79a597acacd53cbad2c7d8 &
-  fetch https://github.com/ahgamut/superconfigure/releases/download/z0.0.60/llvm.zip d42c2e46204d4332975d2d7464c5df63c898c34f8d9d2b83c168c14705ca8edd &
+  fetch https://github.com/ahgamut/superconfigure/releases/download/z0.0.65/aarch64-gcc.zip 61038c275c9e7ae638d1b92548086e705eff0bda880e358459d94b0b4ee28f36 &
+  fetch https://github.com/ahgamut/superconfigure/releases/download/z0.0.65/x86_64-gcc.zip 660a70b24d78c63afbe35f9ec7a06730614e882b464d464b817b007bd412f211 &
+  fetch https://github.com/ahgamut/superconfigure/releases/download/z0.0.65/llvm.zip 30ac89aecc43f9206c0c2ad0f55fee939ac54ae438964fe5a554fd1881a7a8b0 &
   wait
   unzip aarch64-gcc.zip &
   unzip x86_64-gcc.zip &


### PR DESCRIPTION
## Summary

Updates the GCC binaries in cosmocc packaging from z0.0.60 to z0.0.65 to fix segfaults in gvisor environments.

### The problem

The GCC binaries from z0.0.60 (published Nov 2024) use `arch_prctl(ARCH_SET_GS)` for thread-local storage, which gvisor doesn't support. This causes the compiler to segfault when running in gvisor environments (like GitHub Codespaces).

### The fix

z0.0.65 (published Dec 2025) includes GCC binaries built after the tlscc wrapper fix (commit 5ddb5c2a), which uses function calls instead of `arch_prctl` for TLS. These binaries work correctly in gvisor.

### Changes

- `tool/cosmocc/package.sh`: Update GCC binary source from z0.0.60 → z0.0.65 with new SHA256 hashes

## Test plan

- Build cosmocc release using the updated workflow
- Verify gcc/g++ from the new cosmocc doesn't segfault in gvisor