### PR TITLE
build: update cosmocc package script for clang-20

### DIFF
--- a/tool/cosmocc/package.sh
+++ b/tool/cosmocc/package.sh
@@ -289,12 +289,12 @@ if [ ! -x bin/x86_64-linux-cosmo-gcc ]; then
   wait
   unzip aarch64-gcc.zip &
   unzip x86_64-gcc.zip &
-  unzip llvm.zip bin/clang-19 bin/clang-format &
+  unzip llvm.zip bin/clang-20 bin/clang-format &
   wait
   rm -f aarch64-gcc.zip
   rm -f x86_64-gcc.zip
   rm -f llvm.zip
-  mv bin/clang-19 libexec/clang  # use `cosmocc -mclang` instead
+  mv bin/clang-20 libexec/clang  # use `cosmocc -mclang` instead
 fi
 rm -f bin/*-cpp
 rm -f bin/*-gcc-*


### PR DESCRIPTION
## Summary
- Update package.sh to reference clang-20 instead of clang-19
- Fixes cosmocc build failure caused by upstream superconfigure z0.0.65 shipping clang-20

## Test plan
- [ ] Verify cosmocc release workflow completes successfully