### PR TITLE
build: update cosmocc to use whilp/cosmopolitan releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,10 @@ export MODE
 export SOURCE_DATE_EPOCH
 export TMPDIR
 
-COSMOCC = .cosmocc/3.9.2
+COSMOCC = .cosmocc/2025.12.30-0c0b4c8c8
 BOOTSTRAP = $(COSMOCC)/bin
 TOOLCHAIN = $(COSMOCC)/bin/$(ARCH)-linux-cosmo-
-DOWNLOAD := $(shell build/download-cosmocc.sh $(COSMOCC) 3.9.2 f4ff13af65fcd309f3f1cfd04275996fb7f72a4897726628a8c9cf732e850193)
+DOWNLOAD := $(shell build/download-cosmocc.sh $(COSMOCC) cosmocc-2025.12.30-0c0b4c8c8 f6798cad1c8a340f41860ae9d9985eff6e98ac80d5cdcbdf3d3e5e2c47ecc123)
 
 IGNORE := $(shell $(MKDIR) $(TMPDIR))
 

--- a/build/download-cosmocc.sh
+++ b/build/download-cosmocc.sh
@@ -7,7 +7,7 @@
 OUTPUT_DIR=${1:?OUTPUT_DIR}
 COSMOCC_VERSION=${2:?COSMOCC_VERSION}
 COSMOCC_SHA256SUM=${3:?COSMOCC_SHA256SUM}
-URL1="https://github.com/jart/cosmopolitan/releases/download/${COSMOCC_VERSION}/cosmocc-${COSMOCC_VERSION}.zip"
+URL1="https://github.com/whilp/cosmopolitan/releases/download/${COSMOCC_VERSION}/cosmocc.zip"
 URL2="https://cosmo.zip/pub/cosmocc/cosmocc-${COSMOCC_VERSION}.zip"
 
 # helper function


### PR DESCRIPTION
## Summary

- Update `download-cosmocc.sh` to fetch from whilp/cosmopolitan releases instead of jart/cosmopolitan
- Use release tag `cosmocc-2025.12.30-0c0b4c8c8` with verified SHA256 checksum
- Asset naming follows whilp/cosmopolitan convention (`cosmocc.zip`)

## Test plan

- [x] Toolchain downloads successfully with SHA256 verification
- [x] Lua builds and runs correctly