### PR TITLE
build: copy definitions.lua to output directory instead of source tree

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -90,11 +90,12 @@ TOOL_LUA_ASSETS =							\
 o/$(MODE)/tool/lua/definitions.lua.zip.o: private ZIPOBJ_FLAGS += -C2 -P.lua
 o/$(MODE)/tool/lua/cosmo/%.zip.o: private ZIPOBJ_FLAGS += -C2 -P.lua
 
-# Copy base definitions.lua for embedding
-tool/lua/definitions.lua: tool/net/definitions.lua
+# Copy base definitions.lua for embedding to build directory
+o/$(MODE)/tool/lua/definitions.lua: tool/net/definitions.lua
+	@mkdir -p $(dir $@)
 	@cp $< $@
 
-o/$(MODE)/tool/lua/definitions.lua.zip.o: tool/lua/definitions.lua
+o/$(MODE)/tool/lua/definitions.lua.zip.o: o/$(MODE)/tool/lua/definitions.lua
 
 o/$(MODE)/tool/lua/lua.dbg:						\
 		$(TOOL_LUA_DEPS)					\

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -87,8 +87,9 @@ TOOL_LUA_ASSETS =							\
 	o/$(MODE)/tool/lua/cosmo/http/init.lua.zip.o
 
 # Strip tool/lua/ prefix and prepend .lua/ so files end up at /zip/.lua/
-o/$(MODE)/tool/lua/definitions.lua.zip.o: private ZIPOBJ_FLAGS += -C2 -P.lua
 o/$(MODE)/tool/lua/cosmo/%.zip.o: private ZIPOBJ_FLAGS += -C2 -P.lua
+# definitions.lua is copied to o/$(MODE)/ so needs -C4 to strip o/MODE/tool/lua/
+o/$(MODE)/tool/lua/definitions.lua.zip.o: private ZIPOBJ_FLAGS += -C4 -P.lua
 
 # Copy base definitions.lua for embedding to build directory
 o/$(MODE)/tool/lua/definitions.lua: tool/net/definitions.lua


### PR DESCRIPTION
## Summary

Move the build process to copy tool/net/definitions.lua to o/$(MODE)/tool/lua/definitions.lua in the build output directory instead of tool/lua/definitions.lua in the source tree. This keeps the source tree clean and avoids untracked file warnings.

**Changes:**
- Copy definitions.lua to build output directory instead of source tree
- Use `-C4` instead of `-C2` to correctly strip the longer output path when creating the zip object

Fixes the issue where tool/lua/definitions.lua appeared as an untracked file after building.

## Test plan

- [x] Run `make o//tool/lua/test` - all tests pass including test_docs.lua