### PR TITLE
zip: add zip.from() for reading from in-memory buffer

### DIFF
--- a/third_party/lz4cli/BUILD.mk
+++ b/third_party/lz4cli/BUILD.mk
@@ -13,11 +13,16 @@
 
 PKGS += THIRD_PARTY_LZ4CLI
 
+THIRD_PARTY_LZ4CLI_ARTIFACTS += THIRD_PARTY_LZ4CLI_A
+THIRD_PARTY_LZ4CLI_A = o/$(MODE)/third_party/lz4cli/lz4.a
+THIRD_PARTY_LZ4CLI_A_OBJS = o/$(MODE)/third_party/lz4cli/lz4.o
+THIRD_PARTY_LZ4CLI = $(THIRD_PARTY_LZ4CLI_A_DEPS) $(THIRD_PARTY_LZ4CLI_A)
+
 THIRD_PARTY_LZ4CLI_FILES := $(wildcard third_party/lz4cli/*)
 THIRD_PARTY_LZ4CLI_SRCS = $(filter %.c,$(THIRD_PARTY_LZ4CLI_FILES))
 THIRD_PARTY_LZ4CLI_HDRS = $(filter %.h,$(THIRD_PARTY_LZ4CLI_FILES))
 
-THIRD_PARTY_LZ4CLI =					\
+THIRD_PARTY_LZ4CLI_BINS =				\
 	o/$(MODE)/third_party/lz4cli/lz4cli
 
 THIRD_PARTY_LZ4CLI_OBJS =				\
@@ -38,6 +43,14 @@ o/$(MODE)/third_party/lz4cli/datagen.o: private		\
 	DEFAULT_CPPFLAGS +=				\
 		-DSTACK_FRAME_UNLIMITED
 
+THIRD_PARTY_LZ4CLI_A_DIRECTDEPS =			\
+	LIBC_INTRIN					\
+	LIBC_MEM					\
+	LIBC_STR
+
+THIRD_PARTY_LZ4CLI_A_DEPS :=				\
+	$(call uniq,$(foreach x,$(THIRD_PARTY_LZ4CLI_A_DIRECTDEPS),$($(x))))
+
 THIRD_PARTY_LZ4CLI_DIRECTDEPS =				\
 	LIBC_INTRIN					\
 	LIBC_STDIO					\
@@ -45,6 +58,15 @@ THIRD_PARTY_LZ4CLI_DIRECTDEPS =				\
 
 THIRD_PARTY_LZ4CLI_DEPS :=				\
 	$(call uniq,$(foreach x,$(THIRD_PARTY_LZ4CLI_DIRECTDEPS),$($(x))))
+
+$(THIRD_PARTY_LZ4CLI_A):				\
+		third_party/lz4cli/			\
+		$(THIRD_PARTY_LZ4CLI_A).pkg		\
+		$(THIRD_PARTY_LZ4CLI_A_OBJS)
+
+$(THIRD_PARTY_LZ4CLI_A).pkg:				\
+		$(THIRD_PARTY_LZ4CLI_A_OBJS)		\
+		$(foreach x,$(THIRD_PARTY_LZ4CLI_A_DIRECTDEPS),$($(x)_A).pkg)
 
 $(THIRD_PARTY_LZ4CLI_OBJS): private			\
 	DEFAULT_CPPFLAGS +=				\
@@ -62,4 +84,4 @@ $(THIRD_PARTY_LZ4CLI_OBJS):				\
 		third_party/lz4cli/BUILD.mk
 
 .PHONY: o/$(MODE)/third_party/lz4cli
-o/$(MODE)/third_party/lz4cli: $(THIRD_PARTY_LZ4CLI)
+o/$(MODE)/third_party/lz4cli: $(THIRD_PARTY_LZ4CLI) $(THIRD_PARTY_LZ4CLI_BINS)

--- a/tool/lua/cosmo/zip/init.lua
+++ b/tool/lua/cosmo/zip/init.lua
@@ -33,6 +33,13 @@ local function open(path_or_fd, mode_or_opts, opts)
   end
 end
 
+-- Create reader from in-memory zip data
+-- from(data, [opts]) -> reader | nil, error
+local function from(data, opts)
+  return czip.from(data, opts)
+end
+
 return {
   open = open,
+  from = from,
 }

--- a/tool/net/BUILD.mk
+++ b/tool/net/BUILD.mk
@@ -57,22 +57,23 @@ TOOL_NET_DIRECTDEPS =							\
 	NET_HTTPS							\
 	THIRD_PARTY_ARGON2						\
 	THIRD_PARTY_COMPILER_RT						\
+	THIRD_PARTY_DOUBLECONVERSION					\
 	THIRD_PARTY_GDTOA						\
 	THIRD_PARTY_GETOPT						\
 	THIRD_PARTY_LINENOISE						\
 	THIRD_PARTY_LUA							\
 	THIRD_PARTY_LUA_UNIX						\
+	THIRD_PARTY_LZ4CLI						\
 	THIRD_PARTY_MAXMIND						\
-	THIRD_PARTY_MUSL						\
 	THIRD_PARTY_MBEDTLS						\
+	THIRD_PARTY_MUSL						\
 	THIRD_PARTY_REGEX						\
 	THIRD_PARTY_SQLITE3						\
 	THIRD_PARTY_TZ							\
 	THIRD_PARTY_ZLIB						\
 	TOOL_ARGS							\
 	TOOL_BUILD_LIB							\
-	TOOL_DECODE_LIB							\
-	THIRD_PARTY_DOUBLECONVERSION
+	TOOL_DECODE_LIB
 
 TOOL_NET_DEPS :=							\
 	$(call uniq,$(foreach x,$(TOOL_NET_DIRECTDEPS),$($(x))))
@@ -103,7 +104,8 @@ TOOL_NET_REDBEAN_LUA_MODULES =						\
 	o/$(MODE)/tool/net/lmaxmind.o					\
 	o/$(MODE)/tool/net/lsqlite3.o					\
 	o/$(MODE)/tool/net/largon2.o					\
-	o/$(MODE)/tool/net/launch.o
+	o/$(MODE)/tool/net/launch.o					\
+	o/$(MODE)/third_party/lz4cli/lz4.o
 
 o/$(MODE)/tool/net/redbean.dbg:						\
 		$(TOOL_NET_DEPS)					\


### PR DESCRIPTION
## Summary

Adds `zip.from(data)` to create a zip reader from an in-memory string, eliminating the need for temp files when processing zip data that's already in memory (e.g., downloaded from a URL).

## Changes

- Add `data` field to `LuaZipReader` for buffer-backed readers
- Add `ReaderPread` helper that reads from either buffer or fd
- Store a reference to the Lua string in uservalue to prevent GC
- Register `zip.from` in `kLuaZip`
- Expose `zip.from` in Lua wrapper
- Add tests

## Usage

```lua
local zip = require("cosmo.zip")
local reader = zip.from(zip_bytes)
for _, name in ipairs(reader:list()) do
  local content = reader:read(name)
end
reader:close()
```