### PR TITLE
Include cosmos.zip in release SHA256SUMS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,15 +77,15 @@ jobs:
           o/fat/bin/zip -v
           o/fat/bin/unzip -v
 
-      - name: Create checksums
-        run: |
-          cd o/fat/bin
-          sha256sum make zip unzip lua > SHA256SUMS
-
       - name: Create cosmos.zip
         run: |
           cd o/fat/bin
           zip cosmos.zip lua make unzip zip
+
+      - name: Create checksums
+        run: |
+          cd o/fat/bin
+          sha256sum make zip unzip lua cosmos.zip > SHA256SUMS
 
       - name: Create release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.2.0


### PR DESCRIPTION
Moved checksum generation to run after cosmos.zip creation and added cosmos.zip to the sha256sum command. This ensures the cosmos.zip release asset has its checksum included in SHA256SUMS.