### PR TITLE
lua: expose setenv() function in unix module

### DIFF
--- a/test/tool/net/setenv_test.lua
+++ b/test/tool/net/setenv_test.lua
@@ -1,0 +1,42 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+assert(unix.pledge("stdio"))
+
+-- Test basic setenv
+assert(unix.setenv("TEST_VAR", "test_value"))
+assert(os.getenv("TEST_VAR") == "test_value")
+
+-- Test overwrite with default (should overwrite)
+assert(unix.setenv("TEST_VAR", "new_value"))
+assert(os.getenv("TEST_VAR") == "new_value")
+
+-- Test overwrite = true
+assert(unix.setenv("TEST_VAR", "overwritten_value", true))
+assert(os.getenv("TEST_VAR") == "overwritten_value")
+
+-- Test overwrite = false (should not overwrite)
+assert(unix.setenv("TEST_VAR", "should_not_change", false))
+assert(os.getenv("TEST_VAR") == "overwritten_value")
+
+-- Test setting a new variable with overwrite = false
+assert(unix.setenv("ANOTHER_VAR", "another_value", false))
+assert(os.getenv("ANOTHER_VAR") == "another_value")
+
+-- Test with empty value
+assert(unix.setenv("EMPTY_VAR", ""))
+assert(os.getenv("EMPTY_VAR") == "")
+
+print("All setenv tests passed!")

--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -573,6 +573,17 @@ static int LuaUnixEnviron(lua_State *L) {
   return 1;
 }
 
+// unix.setenv(name:str, value:str[, overwrite:bool])
+//     ├─→ true
+//     └─→ nil, unix.Errno
+static int LuaUnixSetenv(lua_State *L) {
+  int olderr = errno;
+  const char *name = luaL_checkstring(L, 1);
+  const char *value = luaL_checkstring(L, 2);
+  int overwrite = lua_isnoneornil(L, 3) ? 1 : lua_toboolean(L, 3);
+  return SysretBool(L, "setenv", olderr, setenv(name, value, overwrite));
+}
+
 // unix.execve(prog:str[, args:List<*>, env:List<*>])
 //     └─→ nil, unix.Errno
 static int LuaUnixExecve(lua_State *L) {
@@ -3618,6 +3629,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"sched_yield", LuaUnixSchedYield},   // relinquish scheduled quantum
     {"send", LuaUnixSend},                // send tcp to some address
     {"sendto", LuaUnixSendto},            // send udp to some address
+    {"setenv", LuaUnixSetenv},            // set environment variable
     {"setfsgid", LuaUnixSetfsgid},        // set/get group id for fs ops
     {"setfsuid", LuaUnixSetfsuid},        // set/get user id for fs ops
     {"setgid", LuaUnixSetgid},            // set real group id of process

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -5302,6 +5302,18 @@ function unix.exit(exitcode) end
 ---@nodiscard
 function unix.environ() end
 
+--- Sets environment variable.
+---
+--- This wraps the C `setenv()` function to allow Lua scripts to set
+--- environment variables.
+---
+--- @param name string environment variable name
+--- @param value string value to set
+--- @param overwrite? boolean if false, won't overwrite existing variables (defaults to true)
+--- @return true
+--- @overload fun(name: string, value: string, overwrite?: boolean): nil, error: unix.Errno
+function unix.setenv(name, value, overwrite) end
+
 --- Creates a new process mitosis style.
 ---
 --- This system call returns twice. The parent process gets the nonzero

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -4141,6 +4141,18 @@ UNIX MODULE
     - `MSG_DONTROUTE`
     - `MSG_NOSIGNAL`
 
+  unix.setenv(name:str, value:str[, overwrite:bool])
+      ├─→ true
+      └─→ nil, unix.Errno
+
+    Sets environment variable.
+
+    This wraps the C `setenv()` function to allow Lua scripts to set
+    environment variables.
+
+    `overwrite` defaults to true. If false, won't overwrite existing
+    variables.
+
   unix.shutdown(fd:int, how:int)
       ├─→ true
       └─→ nil, unix.Errno


### PR DESCRIPTION
Add unix.setenv(name, value, overwrite) to allow Lua scripts to set environment variables. This wraps the C setenv() function which was already available in libc/mem/setenv.c but not exposed to Lua.

Signature:
  unix.setenv(name:str, value:str[, overwrite:bool])
    ├─→ true
    └─→ nil, unix.Errno

- name: environment variable name
- value: value to set
- overwrite: optional boolean (defaults to true). If false, won't overwrite existing variables.

Returns true on success, or nil + unix.Errno on error.

Also includes comprehensive test suite in test/tool/net/setenv_test.lua