### PR TITLE
lua: add unsetenv(), clearenv(), getlogin() and fix environ() NULL handling

### DIFF
--- a/test/tool/net/clearenv_test.lua
+++ b/test/tool/net/clearenv_test.lua
@@ -1,0 +1,44 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+assert(unix.pledge("stdio"))
+
+-- Set some test variables
+assert(unix.setenv("TEST_VAR1", "value1"))
+assert(unix.setenv("TEST_VAR2", "value2"))
+assert(unix.setenv("TEST_VAR3", "value3"))
+
+-- Verify they're set
+assert(os.getenv("TEST_VAR1") == "value1")
+assert(os.getenv("TEST_VAR2") == "value2")
+assert(os.getenv("TEST_VAR3") == "value3")
+
+-- Clear all environment variables
+assert(unix.clearenv())
+
+-- Verify they're all gone
+assert(os.getenv("TEST_VAR1") == nil)
+assert(os.getenv("TEST_VAR2") == nil)
+assert(os.getenv("TEST_VAR3") == nil)
+
+-- Check that environ is empty
+local env = unix.environ()
+assert(#env == 0)
+
+-- Test that we can still set variables after clearing
+assert(unix.setenv("NEW_VAR", "new_value"))
+assert(os.getenv("NEW_VAR") == "new_value")
+
+print("All clearenv tests passed!")

--- a/test/tool/net/getlogin_test.lua
+++ b/test/tool/net/getlogin_test.lua
@@ -1,0 +1,45 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+assert(unix.pledge("stdio"))
+
+-- Test basic getlogin - should return a string or nil
+local login = unix.getlogin()
+
+if login then
+  -- If we got a login name, it should be a non-empty string
+  assert(type(login) == "string")
+  assert(#login > 0)
+  print("Login name: " .. login)
+
+  -- On many systems, getlogin() should match LOGNAME or USER env var
+  local logname = os.getenv("LOGNAME")
+  local user = os.getenv("USER")
+
+  if logname or user then
+    -- At least one should match if available
+    local matches = (login == logname) or (login == user)
+    if not matches then
+      print("Warning: getlogin() returned '" .. login ..
+            "' but LOGNAME=" .. tostring(logname) ..
+            " and USER=" .. tostring(user))
+    end
+  end
+else
+  -- getlogin() can fail in some environments (e.g., no controlling terminal)
+  print("getlogin() returned nil (this is acceptable in some environments)")
+end
+
+print("All getlogin tests passed!")

--- a/test/tool/net/unsetenv_test.lua
+++ b/test/tool/net/unsetenv_test.lua
@@ -1,0 +1,42 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+assert(unix.pledge("stdio"))
+
+-- Set a test variable first
+assert(unix.setenv("TEST_UNSET_VAR", "test_value"))
+assert(os.getenv("TEST_UNSET_VAR") == "test_value")
+
+-- Test basic unsetenv
+assert(unix.unsetenv("TEST_UNSET_VAR"))
+assert(os.getenv("TEST_UNSET_VAR") == nil)
+
+-- Test unsetting a non-existent variable (should succeed)
+assert(unix.unsetenv("NONEXISTENT_VAR"))
+
+-- Test unsetting multiple variables
+assert(unix.setenv("VAR1", "value1"))
+assert(unix.setenv("VAR2", "value2"))
+assert(os.getenv("VAR1") == "value1")
+assert(os.getenv("VAR2") == "value2")
+
+assert(unix.unsetenv("VAR1"))
+assert(os.getenv("VAR1") == nil)
+assert(os.getenv("VAR2") == "value2")
+
+assert(unix.unsetenv("VAR2"))
+assert(os.getenv("VAR2") == nil)
+
+print("All unsetenv tests passed!")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -5314,6 +5314,34 @@ function unix.environ() end
 --- @overload fun(name: string, value: string, overwrite?: boolean): nil, error: unix.Errno
 function unix.setenv(name, value, overwrite) end
 
+--- Unsets environment variable.
+---
+--- This wraps the C `unsetenv()` function to allow Lua scripts to remove
+--- environment variables.
+---
+--- @param name string environment variable name to unset
+--- @return true
+--- @overload fun(name: string): nil, error: unix.Errno
+function unix.unsetenv(name) end
+
+--- Clears all environment variables.
+---
+--- This wraps the C `clearenv()` function to allow Lua scripts to remove
+--- all environment variables at once.
+---
+--- @return true
+--- @overload fun(): nil, error: unix.Errno
+function unix.clearenv() end
+
+--- Gets login name of current user.
+---
+--- This wraps the C `getlogin()` function to retrieve the login name
+--- associated with the current session.
+---
+--- @return string login name
+--- @overload fun(): nil, error: unix.Errno
+function unix.getlogin() end
+
 --- Creates a new process mitosis style.
 ---
 --- This system call returns twice. The parent process gets the nonzero

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -4153,6 +4153,33 @@ UNIX MODULE
     `overwrite` defaults to true. If false, won't overwrite existing
     variables.
 
+  unix.unsetenv(name:str)
+      ├─→ true
+      └─→ nil, unix.Errno
+
+    Unsets environment variable.
+
+    This wraps the C `unsetenv()` function to allow Lua scripts to remove
+    environment variables.
+
+  unix.clearenv()
+      ├─→ true
+      └─→ nil, unix.Errno
+
+    Clears all environment variables.
+
+    This wraps the C `clearenv()` function to allow Lua scripts to remove
+    all environment variables at once.
+
+  unix.getlogin()
+      ├─→ str
+      └─→ nil, unix.Errno
+
+    Gets login name of current user.
+
+    This wraps the C `getlogin()` function to retrieve the login name
+    associated with the current session.
+
   unix.shutdown(fd:int, how:int)
       ├─→ true
       └─→ nil, unix.Errno


### PR DESCRIPTION
## Summary

Add three new environment and user functions to the unix module, complementing the recently added `setenv()` function:

- **`unix.unsetenv(name)`** - Remove a specific environment variable
- **`unix.clearenv()`** - Remove all environment variables at once  
- **`unix.getlogin()`** - Get login name of current user

All functions follow the existing error handling pattern, returning `true` on success (or the login string for `getlogin`) or `nil, unix.Errno` on error.

## Bug fix

Fixes `unix.environ()` to handle NULL `environ` pointer which can occur after calling `clearenv()`. This prevents a potential segfault when checking the environment after clearing it.

## Changes

- `third_party/lua/lunix.c`: Add three new functions and fix environ() NULL check
- `tool/net/definitions.lua`: Add LSP type definitions for new functions
- `tool/net/help.txt`: Add documentation for new functions
- `test/tool/net/{unsetenv,clearenv,getlogin}_test.lua`: Comprehensive test suites

## Security considerations

- `unsetenv()` uses `luaL_checkstring()` for input validation
- `clearenv()` has no user input - directly wraps the C function
- `getlogin()` properly handles NULL returns and copies the static buffer before returning
- The `environ()` fix prevents NULL pointer dereference

## Test plan

- [x] Build passes
- [ ] Run unsetenv tests: `o//tool/net/redbean.dbg -i test/tool/net/unsetenv_test.lua`
- [ ] Run clearenv tests: `o//tool/net/redbean.dbg -i test/tool/net/clearenv_test.lua`
- [ ] Run getlogin tests: `o//tool/net/redbean.dbg -i test/tool/net/getlogin_test.lua`