### PR TITLE
lua: remove --skill/--embed options, use preload for modules

### DIFF
--- a/third_party/lua/lua.main.c
+++ b/third_party/lua/lua.main.c
@@ -88,8 +88,6 @@ static void print_usage (const char *badoption) {
   "  -v        show version information\n"
   "  -E        ignore environment variables\n"
   "  -W        turn warnings on\n"
-  "  --skill [path]  install Claude Code skill\n"
-  "  --embed <package> [output]  embed Lua library into executable\n"
   "  --        stop handling options\n"
   "  -         stop handling options and execute stdin\n"
   ,
@@ -198,12 +196,6 @@ static int handle_script (lua_State *L, char **argv) {
 #define has_v		4	/* -v */
 #define has_e		8	/* -e */
 #define has_E		16	/* -E */
-#define has_skill	32	/* --skill */
-#define has_embed	64	/* --embed */
-
-static const char *skill_path = NULL;  /* optional path for --skill */
-static const char *embed_package = NULL;  /* required package for --embed */
-static const char *embed_output = NULL;  /* optional output path for --embed */
 
 
 /*
@@ -229,33 +221,11 @@ static int collectargs (char **argv, int *first) {
     if (argv[i][0] != '-')  /* not an option? */
         return args;  /* stop handling options */
     switch (argv[i][1]) {  /* else check option */
-      case '-':  /* '--' or '--skill' */
-        if (argv[i][2] == '\0') {  /* bare '--' */
-          *first = i + 1;
-          return args;
-        }
-        if (strcmp(argv[i], "--skill") == 0) {  /* --skill [path] */
-          args |= has_skill;
-          /* check for optional path argument */
-          if (argv[i + 1] != NULL && argv[i + 1][0] != '-') {
-            skill_path = argv[++i];
-          }
-          break;
-        }
-        if (strcmp(argv[i], "--embed") == 0) {  /* --embed <package> [output] */
-          args |= has_embed;
-          /* package name is required */
-          if (argv[i + 1] == NULL || argv[i + 1][0] == '-') {
-            return has_error;  /* missing package name */
-          }
-          embed_package = argv[++i];
-          /* check for optional output path */
-          if (argv[i + 1] != NULL && argv[i + 1][0] != '-') {
-            embed_output = argv[++i];
-          }
-          break;
-        }
-        return has_error;  /* unknown long option */
+      case '-':  /* '--' */
+        if (argv[i][2] != '\0')  /* extra characters after '--'? */
+          return has_error;  /* invalid option */
+        *first = i + 1;
+        return args;
       case '\0':  /* '-' */
         return args;  /* script "name" is '-' */
       case 'E':
@@ -406,53 +376,15 @@ static int pmain (lua_State *L) {
     lua_setfield(L, LUA_REGISTRYINDEX, "LUA_NOENV");
   }
   luaL_openlibs(L);  /* open standard libraries */
+  /* preload cosmo/unix modules (available via require, not auto-loaded) */
+  luaL_getsubtable(L, LUA_REGISTRYINDEX, LUA_PRELOAD_TABLE);
 #ifdef LUA_COSMO
-  luaL_requiref(L, "cosmo", luaopen_cosmo, 1);
-#else
-  luaL_requiref(L, "unix", LuaUnix, 1);
+  lua_pushcfunction(L, luaopen_cosmo);
+  lua_setfield(L, -2, "cosmo");
 #endif
-  lua_pop(L, 1);
-  /* handle --skill option */
-  if (args & has_skill) {
-    lua_getglobal(L, "require");
-    lua_pushliteral(L, "cosmo.skill");
-    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
-      lua_report(L, LUA_ERRRUN);
-      return 0;
-    }
-    lua_getfield(L, -1, "install");
-    if (skill_path)
-      lua_pushstring(L, skill_path);
-    else
-      lua_pushnil(L);
-    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
-      lua_report(L, LUA_ERRRUN);
-      return 0;
-    }
-    lua_pushboolean(L, lua_toboolean(L, -1));
-    return 1;  /* exit after installing skill */
-  }
-  /* handle --embed option */
-  if (args & has_embed) {
-    lua_getglobal(L, "require");
-    lua_pushliteral(L, "cosmo.embed");
-    if (lua_pcall(L, 1, 1, 0) != LUA_OK) {
-      lua_report(L, LUA_ERRRUN);
-      return 0;
-    }
-    lua_getfield(L, -1, "install");
-    lua_pushstring(L, embed_package);
-    if (embed_output)
-      lua_pushstring(L, embed_output);
-    else
-      lua_pushnil(L);
-    if (lua_pcall(L, 2, 1, 0) != LUA_OK) {
-      lua_report(L, LUA_ERRRUN);
-      return 0;
-    }
-    lua_pushboolean(L, lua_toboolean(L, -1));
-    return 1;  /* exit after embedding library */
-  }
+  lua_pushcfunction(L, LuaUnix);
+  lua_setfield(L, -2, "unix");
+  lua_pop(L, 1);  /* remove PRELOAD table */
   createargtable(L, argv, argc, script);  /* create table 'arg' */
   lua_gc(L, LUA_GCRESTART);  /* start GC... */
   lua_gc(L, LUA_GCGEN, 0, 0);  /* ...in generational mode */

--- a/third_party/lua/lua.main.c
+++ b/third_party/lua/lua.main.c
@@ -52,6 +52,15 @@
 #include "third_party/lua/lunix.h"
 #ifdef LUA_COSMO
 #include "third_party/lua/lcosmo.h"
+/* Forward declarations for cosmo submodules */
+int LuaPath(lua_State *);
+int LuaRe(lua_State *);
+int LuaGetopt(lua_State *);
+int LuaZip(lua_State *);
+int LuaHttp(lua_State *);
+int LuaGoodSocket(lua_State *);
+int luaopen_argon2(lua_State *);
+int luaopen_lsqlite3(lua_State *);
 #endif
 #include "libc/cosmo.h"
 __static_yoink("lua_notice");
@@ -381,9 +390,27 @@ static int pmain (lua_State *L) {
 #ifdef LUA_COSMO
   lua_pushcfunction(L, luaopen_cosmo);
   lua_setfield(L, -2, "cosmo");
+  lua_pushcfunction(L, LuaPath);
+  lua_setfield(L, -2, "cosmo.path");
+  lua_pushcfunction(L, LuaRe);
+  lua_setfield(L, -2, "cosmo.re");
+  lua_pushcfunction(L, LuaGetopt);
+  lua_setfield(L, -2, "cosmo.getopt");
+  lua_pushcfunction(L, LuaZip);
+  lua_setfield(L, -2, "cosmo.zip.c");
+  lua_pushcfunction(L, LuaHttp);
+  lua_setfield(L, -2, "cosmo.http");
+  lua_pushcfunction(L, LuaGoodSocket);
+  lua_setfield(L, -2, "cosmo.goodsocket");
+  lua_pushcfunction(L, luaopen_argon2);
+  lua_setfield(L, -2, "cosmo.argon2");
+  lua_pushcfunction(L, luaopen_lsqlite3);
+  lua_setfield(L, -2, "cosmo.lsqlite3");
 #endif
   lua_pushcfunction(L, LuaUnix);
   lua_setfield(L, -2, "unix");
+  lua_pushcfunction(L, LuaUnix);
+  lua_setfield(L, -2, "cosmo.unix");
   lua_pop(L, 1);  /* remove PRELOAD table */
   createargtable(L, argv, argc, script);  /* create table 'arg' */
   lua_gc(L, LUA_GCRESTART);  /* start GC... */


### PR DESCRIPTION
## Summary

- Remove `--skill` and `--embed` command-line options from lua.main.c
- Change cosmo/unix modules from auto-loading to preload registration
- Brings lua.main.c closer to upstream Lua 5.4.6

## Details

The `--skill` and `--embed` features are still available via Lua modules:

```bash
lua -e 'require("cosmo.skill").install()'
lua -e 'require("cosmo.embed").install("package")'
lua -e 'require("cosmo.help")()'
```

The `unix` and `cosmo` modules are now registered as preloads instead of being auto-loaded into global scope:

```lua
-- Before: unix was in global scope
-- After: must require explicitly
local unix = require("unix")
```

## Test plan

- [x] Build succeeds: `make o//third_party/lua/lua`
- [x] `lua -v` works
- [x] `--skill` and `--embed` are properly rejected as unknown options
- [x] `require("unix")` works
- [x] `unix` is not in global scope by default