### PR TITLE
bootstrap cosmic

### DIFF
--- a/.claude/settings
+++ b/.claude/settings
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "make --no-print-directory -C \"$CLAUDE_PROJECT_DIR\" bootstrap"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && bin/cosmic --version >/dev/null 2>&1 && test -e bin/lua || ln -sf cosmic-lua bin/lua && echo \"export PATH=\\\"$CLAUDE_PROJECT_DIR/bin:\\$PATH\\\"\" >> \"$CLAUDE_ENV_FILE\""
           }
         ]
       }

--- a/.claude/settings
+++ b/.claude/settings
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cd \"$CLAUDE_PROJECT_DIR\" && bin/cosmic --version >/dev/null 2>&1 && test -e bin/lua || ln -sf cosmic-lua bin/lua && echo \"export PATH=\\\"$CLAUDE_PROJECT_DIR/bin:\\$PATH\\\"\" >> \"$CLAUDE_ENV_FILE\""
+            "command": "\"$CLAUDE_PROJECT_DIR/bin/cosmic\" --skill bootstrap"
           }
         ]
       }

--- a/.github/pr/add-cosmic-bin-script.md
+++ b/.github/pr/add-cosmic-bin-script.md
@@ -1,12 +1,13 @@
 # bin: add cosmic bootstrap script
 
-Adds a shell script that downloads and executes cosmic-lua from GitHub releases, and updates Claude Code settings to use it directly.
+Adds a shell script that downloads and executes cosmic-lua from GitHub releases, and integrates it with Claude Code settings and GitHub workflows.
 
 - bin/cosmic - bootstrap script that downloads cosmic-lua on first run and executes it with arguments
-- .claude/settings - updated SessionStart hook to run bin/cosmic directly
+- .claude/settings - updated SessionStart hook to run bin/cosmic --skill bootstrap
+- .github/workflows/pr.yml - added update-pr job that runs bin/cosmic --skill pr
 - Makefile - removed bootstrap target (now handled by Claude Code hook)
 
-The script automatically downloads the cosmic-lua binary from the GitHub release URL (home-2026-01-05-a64eed2) on first run, caches it in the bin directory, and executes it with any provided arguments. The Claude Code SessionStart hook now runs bin/cosmic directly to set up the environment.
+The script automatically downloads the cosmic-lua binary from the GitHub release URL (home-2026-01-05-a64eed2) on first run, caches it in the bin directory, and executes it with any provided arguments. The Claude Code SessionStart hook runs bin/cosmic --skill bootstrap to set up the environment, and the PR workflow uses bin/cosmic --skill pr to update PR titles and descriptions from .github/pr/ files.
 
 ## Validation
 
@@ -14,5 +15,6 @@ The script automatically downloads the cosmic-lua binary from the GitHub release
 - [x] Script includes error handling (set -e)
 - [x] Downloads from newer release URL
 - [x] Caches binary for subsequent runs
-- [x] Claude Code settings updated to use bin/cosmic
+- [x] Claude Code settings updated to use bin/cosmic --skill bootstrap
+- [x] PR workflow updated to use bin/cosmic --skill pr
 - [x] Makefile bootstrap target removed

--- a/.github/pr/add-cosmic-bin-script.md
+++ b/.github/pr/add-cosmic-bin-script.md
@@ -1,11 +1,12 @@
 # bin: add cosmic bootstrap script
 
-Adds a shell script that downloads and executes cosmic-lua from GitHub releases, and simplifies the Makefile bootstrap target to use it.
+Adds a shell script that downloads and executes cosmic-lua from GitHub releases, and updates Claude Code settings to use it directly.
 
 - bin/cosmic - bootstrap script that downloads cosmic-lua on first run and executes it with arguments
-- Makefile - simplified bootstrap target to delegate to bin/cosmic script
+- .claude/settings - updated SessionStart hook to run bin/cosmic directly
+- Makefile - removed bootstrap target (now handled by Claude Code hook)
 
-The script automatically downloads the cosmic-lua binary from the GitHub release URL (home-2026-01-05-a64eed2) on first run, caches it in the bin directory, and executes it with any provided arguments. The Makefile bootstrap target now simply runs bin/cosmic to trigger the download, creates the bin/lua symlink, and updates PATH.
+The script automatically downloads the cosmic-lua binary from the GitHub release URL (home-2026-01-05-a64eed2) on first run, caches it in the bin directory, and executes it with any provided arguments. The Claude Code SessionStart hook now runs bin/cosmic directly to set up the environment.
 
 ## Validation
 
@@ -13,4 +14,5 @@ The script automatically downloads the cosmic-lua binary from the GitHub release
 - [x] Script includes error handling (set -e)
 - [x] Downloads from newer release URL
 - [x] Caches binary for subsequent runs
-- [x] Makefile bootstrap simplified to use bin/cosmic
+- [x] Claude Code settings updated to use bin/cosmic
+- [x] Makefile bootstrap target removed

--- a/.github/pr/add-cosmic-bin-script.md
+++ b/.github/pr/add-cosmic-bin-script.md
@@ -1,0 +1,14 @@
+# bin: add cosmic bootstrap script
+
+Adds a shell script that downloads and executes cosmic-lua from GitHub releases.
+
+- bin/cosmic - bootstrap script that downloads cosmic-lua on first run and executes it with arguments
+
+The script automatically downloads the cosmic-lua binary from the GitHub release URL on first run, caches it in the bin directory, and executes it with any provided arguments. This allows users to run cosmic-lua without manually downloading the binary.
+
+## Validation
+
+- [x] Script created with proper permissions
+- [x] Script includes error handling (set -e)
+- [x] Downloads from specified release URL
+- [x] Caches binary for subsequent runs

--- a/.github/pr/add-cosmic-bin-script.md
+++ b/.github/pr/add-cosmic-bin-script.md
@@ -1,14 +1,16 @@
 # bin: add cosmic bootstrap script
 
-Adds a shell script that downloads and executes cosmic-lua from GitHub releases.
+Adds a shell script that downloads and executes cosmic-lua from GitHub releases, and simplifies the Makefile bootstrap target to use it.
 
 - bin/cosmic - bootstrap script that downloads cosmic-lua on first run and executes it with arguments
+- Makefile - simplified bootstrap target to delegate to bin/cosmic script
 
-The script automatically downloads the cosmic-lua binary from the GitHub release URL on first run, caches it in the bin directory, and executes it with any provided arguments. This allows users to run cosmic-lua without manually downloading the binary.
+The script automatically downloads the cosmic-lua binary from the GitHub release URL (home-2026-01-05-a64eed2) on first run, caches it in the bin directory, and executes it with any provided arguments. The Makefile bootstrap target now simply runs bin/cosmic to trigger the download, creates the bin/lua symlink, and updates PATH.
 
 ## Validation
 
 - [x] Script created with proper permissions
 - [x] Script includes error handling (set -e)
-- [x] Downloads from specified release URL
+- [x] Downloads from newer release URL
 - [x] Caches binary for subsequent runs
+- [x] Makefile bootstrap simplified to use bin/cosmic

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,20 @@ on:
       - master
 
 jobs:
+  update-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Update PR title and description
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          bin/cosmic --skill pr
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -633,12 +633,6 @@ aarch64:
 clean:
 	$(RM) -r o
 
-.PHONY: bootstrap
-bootstrap:
-	@bin/cosmic --version >/dev/null 2>&1  # Trigger cosmic-lua download on first run
-	@test -e bin/lua || ln -sf cosmic-lua bin/lua
-	@test -z "$$CLAUDE_ENV_FILE" || $(ECHO) "export PATH=\"$(CURDIR)/bin:$$PATH\"" >> "$$CLAUDE_ENV_FILE"
-
 # UNSPECIFIED PREREQUISITES TUTORIAL
 #
 # A build rule must exist for all files that make needs to consider in

--- a/Makefile
+++ b/Makefile
@@ -633,14 +633,10 @@ aarch64:
 clean:
 	$(RM) -r o
 
-bin/cosmic-lua:
-	@$(MKDIR) bin
-	@curl -ssLo $@ https://github.com/whilp/world/releases/download/home-2026-01-03-11aa802/cosmic-lua
-	@$(CHMOD) 755 $@
-	@ln -sf cosmic-lua bin/lua
-
 .PHONY: bootstrap
-bootstrap: bin/cosmic-lua
+bootstrap:
+	@bin/cosmic --version >/dev/null 2>&1  # Trigger cosmic-lua download on first run
+	@test -e bin/lua || ln -sf cosmic-lua bin/lua
 	@test -z "$$CLAUDE_ENV_FILE" || $(ECHO) "export PATH=\"$(CURDIR)/bin:$$PATH\"" >> "$$CLAUDE_ENV_FILE"
 
 # UNSPECIFIED PREREQUISITES TUTORIAL

--- a/bin/cosmic
+++ b/bin/cosmic
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+COSMIC_LUA="${SCRIPT_DIR}/cosmic-lua"
+RELEASE_URL="https://github.com/whilp/world/releases/download/home-2026-01-05-a64eed2/cosmic-lua"
+
+# Download cosmic-lua if it doesn't exist
+if [ ! -f "${COSMIC_LUA}" ]; then
+    echo "Downloading cosmic-lua..." >&2
+    curl -fsSL -o "${COSMIC_LUA}" "${RELEASE_URL}"
+    chmod +x "${COSMIC_LUA}"
+fi
+
+# Execute cosmic-lua with all arguments
+exec "${COSMIC_LUA}" "$@"


### PR DESCRIPTION
# bin: add cosmic bootstrap script

Adds a shell script that downloads and executes cosmic-lua from GitHub releases, and integrates it with Claude Code settings and GitHub workflows.

- bin/cosmic - bootstrap script that downloads cosmic-lua on first run and executes it with arguments
- .claude/settings - updated SessionStart hook to run bin/cosmic --skill bootstrap
- .github/workflows/pr.yml - added update-pr job that runs bin/cosmic --skill pr
- Makefile - removed bootstrap target (now handled by Claude Code hook)

The script automatically downloads the cosmic-lua binary from the GitHub release URL (home-2026-01-05-a64eed2) on first run, caches it in the bin directory, and executes it with any provided arguments. The Claude Code SessionStart hook runs bin/cosmic --skill bootstrap to set up the environment, and the PR workflow uses bin/cosmic --skill pr to update PR titles and descriptions from .github/pr/ files.

## Validation

- [x] Script created with proper permissions
- [x] Script includes error handling (set -e)
- [x] Downloads from newer release URL
- [x] Caches binary for subsequent runs
- [x] Claude Code settings updated to use bin/cosmic --skill bootstrap
- [x] PR workflow updated to use bin/cosmic --skill pr
- [x] Makefile bootstrap target removed
