### PR TITLE
lua: fix unix.isatty() return semantics

### DIFF
--- a/.github/pr/fix-isatty-return-semantics.md
+++ b/.github/pr/fix-isatty-return-semantics.md
@@ -1,0 +1,15 @@
+# lua: fix unix.isatty() return semantics
+
+Fixes a bug in `unix.isatty()` where it incorrectly returned `true` for non-tty file descriptors and generated warnings when checking actual ttys.
+
+## Changes
+
+- `third_party/lua/lunix.c` - rewrote `LuaUnixIsatty()` to handle isatty()'s tri-state return (1/0/-1) instead of using `SysretBool()` which expects binary returns (0/-1)
+- `tool/lua/test_isatty.lua` - added test demonstrating the fix
+- `tool/lua/BUILD.mk` - registered new test in build system
+
+The `isatty()` syscall returns 1 for tty, 0 for non-tty, and -1 for error. The previous implementation used `SysretBool()` which expects 0 for success and -1 for error, causing two bugs:
+1. Warning "syscall supposed to return 0 / -1 but got 1" when fd was a tty
+2. Returned `true` when `isatty()` returned 0 (non-tty), should return `false`
+
+The fix properly handles all three return states and includes tests to prevent regression.

--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -2270,10 +2270,17 @@ static int LuaUnixSissock(lua_State *L) {
 
 // unix.isatty(fd:int)
 //     ├─→ true
+//     ├─→ false
 //     └─→ nil, unix.Errno
 static int LuaUnixIsatty(lua_State *L) {
   int olderr = errno;
-  return SysretBool(L, "isatty", olderr, isatty(luaL_checkinteger(L, 1)));
+  int rc = isatty(luaL_checkinteger(L, 1));
+  if (rc == -1) {
+    return LuaUnixSysretErrno(L, "isatty", olderr);
+  } else {
+    lua_pushboolean(L, rc != 0);
+    return 1;
+  }
 }
 
 // unix.tiocgwinsz(fd:int)

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -184,6 +184,10 @@ o/$(MODE)/tool/lua/test_unix_proc.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_u
 	$< tool/lua/test_unix_proc.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_isatty.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_isatty.lua
+	$< tool/lua/test_isatty.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
 	o/$(MODE)/tool/lua/cosmo/help/test.ok				\
@@ -202,7 +206,8 @@ TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_goodsocket.ok				\
 	o/$(MODE)/tool/lua/test_embed.ok				\
 	o/$(MODE)/tool/lua/test_embed_integration.ok			\
-	o/$(MODE)/tool/lua/test_unix_proc.ok
+	o/$(MODE)/tool/lua/test_unix_proc.ok				\
+	o/$(MODE)/tool/lua/test_isatty.ok
 
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\

--- a/tool/lua/test_isatty.lua
+++ b/tool/lua/test_isatty.lua
@@ -1,0 +1,29 @@
+-- Test for unix.isatty
+local unix = require("cosmo.unix")
+
+-- Test 1: isatty on a regular file should return false
+-- This demonstrates the semantic bug where it currently returns true
+local fd = unix.open("/dev/null", unix.O_RDONLY)
+assert(fd, "should be able to open /dev/null")
+
+local result = unix.isatty(fd)
+assert(result == false, "isatty on /dev/null should return false, got: " .. tostring(result))
+
+unix.close(fd)
+
+-- Test 2: isatty on stdout (if it's a tty) should return true
+-- This triggers the warning: "syscall supposed to return 0 / -1 but got 1"
+local result = unix.isatty(1)
+-- We can't assert the result because it depends on whether stdout is a tty
+-- but if it IS a tty, this will trigger the warning
+if result then
+  print("stdout is a tty (this should trigger warning in buggy version)")
+end
+
+-- Test 3: isatty on an invalid/closed fd might return false or error depending on the fd number
+-- For a high fd number that doesn't exist, it may return false (not a tty)
+-- Let's just verify it doesn't crash and returns a boolean or nil
+local result, err = unix.isatty(999999)
+assert(type(result) == "boolean" or result == nil, "isatty should return boolean or nil")
+
+print("all isatty tests passed")


### PR DESCRIPTION
# lua: fix unix.isatty() return semantics

Fixes a bug in `unix.isatty()` where it incorrectly returned `true` for non-tty file descriptors and generated warnings when checking actual ttys.

## Changes

- `third_party/lua/lunix.c` - rewrote `LuaUnixIsatty()` to handle isatty()'s tri-state return (1/0/-1) instead of using `SysretBool()` which expects binary returns (0/-1)
- `tool/lua/test_isatty.lua` - added test demonstrating the fix
- `tool/lua/BUILD.mk` - registered new test in build system

The `isatty()` syscall returns 1 for tty, 0 for non-tty, and -1 for error. The previous implementation used `SysretBool()` which expects 0 for success and -1 for error, causing two bugs:
1. Warning "syscall supposed to return 0 / -1 but got 1" when fd was a tty
2. Returned `true` when `isatty()` returned 0 (non-tty), should return `false`

The fix properly handles all three return states and includes tests to prevent regression.