### PR TITLE
lua: add UnescapeParam for URL decoding

### DIFF
--- a/net/http/escape.h
+++ b/net/http/escape.h
@@ -22,6 +22,7 @@ char *EscapeIp(const char *, size_t, size_t *) libcesque;
 char *EscapeHost(const char *, size_t, size_t *) libcesque;
 char *EscapePath(const char *, size_t, size_t *) libcesque;
 char *EscapeParam(const char *, size_t, size_t *) libcesque;
+char *UnescapeParam(const char *, size_t, size_t *) libcesque;
 char *EscapeFragment(const char *, size_t, size_t *) libcesque;
 char *EscapeSegment(const char *, size_t, size_t *) libcesque;
 char *EscapeJsStringLiteral(char **, size_t *, const char *, size_t,

--- a/net/http/unescapeparam.c
+++ b/net/http/unescapeparam.c
@@ -1,0 +1,64 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2025 Will Maier                                                    │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for        │
+│ any purpose with or without fee is hereby granted, provided that the        │
+│ above copyright notice and this permission notice appear in all copies.     │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL               │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED               │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE            │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL        │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR       │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER              │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR            │
+│ PERFORMANCE OF THIS SOFTWARE.                                               │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/mem/mem.h"
+#include "libc/str/str.h"
+#include "libc/str/tab.h"
+#include "net/http/escape.h"
+
+/**
+ * Unescapes URL query/form parameter.
+ *
+ * This decodes percent-encoded sequences (%XX) and optionally converts
+ * '+' to space (common in application/x-www-form-urlencoded).
+ *
+ * @param p is input value
+ * @param n if -1 implies strlen
+ * @param z if non-NULL receives output length
+ * @return allocated NUL-terminated buffer, or NULL w/ errno
+ */
+char *UnescapeParam(const char *p, size_t n, size_t *z) {
+  int a, b, c;
+  char *r, *q;
+  size_t i;
+  if (z)
+    *z = 0;
+  if (n == (size_t)-1)
+    n = p ? strlen(p) : 0;
+  if ((q = r = malloc(n + 1))) {
+    for (i = 0; i < n; i++) {
+      c = p[i] & 255;
+      if (c == '%' && i + 2 < n &&
+          (a = kHexToInt[p[i + 1] & 255]) != -1 &&
+          (b = kHexToInt[p[i + 2] & 255]) != -1) {
+        *q++ = (a << 4) | b;
+        i += 2;
+      } else if (c == '+') {
+        *q++ = ' ';
+      } else {
+        *q++ = c;
+      }
+    }
+    if (z)
+      *z = q - r;
+    *q++ = '\0';
+    if ((q = realloc(r, q - r)))
+      r = q;
+  }
+  return r;
+}

--- a/test/net/http/unescapeparam_test.c
+++ b/test/net/http/unescapeparam_test.c
@@ -1,0 +1,97 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2025 Will Maier                                                    │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for        │
+│ any purpose with or without fee is hereby granted, provided that the        │
+│ above copyright notice and this permission notice appear in all copies.     │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL               │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED               │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE            │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL        │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR       │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER              │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR            │
+│ PERFORMANCE OF THIS SOFTWARE.                                               │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/mem/gc.h"
+#include "libc/mem/mem.h"
+#include "libc/str/str.h"
+#include "libc/testlib/ezbench.h"
+#include "libc/testlib/hyperion.h"
+#include "libc/testlib/testlib.h"
+#include "net/http/escape.h"
+
+char *unescapeparam(const char *s) {
+  char *p;
+  size_t n;
+  p = UnescapeParam(s, -1, &n);
+  ASSERT_EQ(strlen(p), n);
+  return p;
+}
+
+TEST(UnescapeParam, testBasic) {
+  EXPECT_STREQ("abc &<>\"'\1\2",
+               gc(unescapeparam("abc%20%26%3C%3E%22%27%01%02")));
+}
+
+TEST(UnescapeParam, testPlusAsSpace) {
+  EXPECT_STREQ("hello world", gc(unescapeparam("hello+world")));
+}
+
+TEST(UnescapeParam, testMixedPlusAndPercent) {
+  EXPECT_STREQ("hello world", gc(unescapeparam("hello%20world")));
+  EXPECT_STREQ("a b c", gc(unescapeparam("a+b%20c")));
+}
+
+TEST(UnescapeParam, testEmpty) {
+  EXPECT_STREQ("", gc(unescapeparam("")));
+}
+
+TEST(UnescapeParam, testNoEscapes) {
+  EXPECT_STREQ("hello", gc(unescapeparam("hello")));
+}
+
+TEST(UnescapeParam, testIncompleteEscape) {
+  /* incomplete %XX should be preserved */
+  EXPECT_STREQ("%2", gc(unescapeparam("%2")));
+  EXPECT_STREQ("%", gc(unescapeparam("%")));
+  EXPECT_STREQ("a%", gc(unescapeparam("a%")));
+  EXPECT_STREQ("a%2", gc(unescapeparam("a%2")));
+}
+
+TEST(UnescapeParam, testInvalidHex) {
+  /* invalid hex should be preserved */
+  EXPECT_STREQ("%XY", gc(unescapeparam("%XY")));
+  EXPECT_STREQ("%2G", gc(unescapeparam("%2G")));
+}
+
+TEST(UnescapeParam, testUtf8) {
+  /* UTF-8 encoded chars */
+  EXPECT_STREQ("𐌰", gc(unescapeparam("%F0%90%8C%B0")));
+}
+
+TEST(UnescapeParam, testLowerAndUpperHex) {
+  EXPECT_STREQ(" ", gc(unescapeparam("%20")));
+  EXPECT_STREQ("~", gc(unescapeparam("%7e")));
+  EXPECT_STREQ("~", gc(unescapeparam("%7E")));
+}
+
+TEST(UnescapeParam, testRoundTrip) {
+  /* EscapeParam then UnescapeParam should give original */
+  const char *orig = "hello world!";
+  char *escaped = EscapeParam(orig, -1, NULL);
+  char *result = UnescapeParam(escaped, -1, NULL);
+  EXPECT_STREQ(orig, result);
+  free(escaped);
+  free(result);
+}
+
+BENCH(UnescapeParam, bench) {
+  char *escaped = EscapeParam(kHyperion, kHyperionSize, 0);
+  EZBENCH2("UnescapeParam", donothing,
+           free(UnescapeParam(escaped, -1, 0)));
+  free(escaped);
+}

--- a/test/tool/net/lfuncs_test.lua
+++ b/test/tool/net/lfuncs_test.lua
@@ -69,6 +69,12 @@ assert(EscapeHtml("?hello&there<>") == "?hello&amp;there&lt;&gt;")
 assert(EscapeParam(nil) == nil)
 assert(EscapeParam("?hello&there<>") == "%3Fhello%26there%3C%3E")
 
+assert(UnescapeParam(nil) == nil)
+assert(UnescapeParam("%3Fhello%26there%3C%3E") == "?hello&there<>")
+assert(UnescapeParam("hello+world") == "hello world")
+assert(UnescapeParam("hello%20world") == "hello world")
+assert(UnescapeParam(EscapeParam("hello world!")) == "hello world!")
+
 assert(DecodeLatin1(nil) == nil)
 assert(DecodeLatin1("hello\xff\xc0") == "helloÿÀ")
 assert(EncodeLatin1("helloÿÀ") == "hello\xff\xc0")

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -198,6 +198,7 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"EscapeIp", LuaEscapeIp},
     {"EscapeLiteral", LuaEscapeLiteral},
     {"EscapeParam", LuaEscapeParam},
+    {"UnescapeParam", LuaUnescapeParam},
     {"EscapePass", LuaEscapePass},
     {"EscapePath", LuaEscapePath},
     {"EscapeSegment", LuaEscapeSegment},

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -1056,6 +1056,14 @@ function EscapeLiteral(str) end
 ---@nodiscard
 function EscapeParam(str) end
 
+--- Unescapes URL parameter name or value. Decodes `%XX` hex sequences and
+--- converts `+` to space (common in application/x-www-form-urlencoded).
+--- This is the inverse of EscapeParam.
+---@param str string
+---@return string
+---@nodiscard
+function UnescapeParam(str) end
+
 --- Escapes URL password. See `kescapeauthority.S`.
 ---@param str string
 ---@return string

--- a/tool/net/lfuncs.c
+++ b/tool/net/lfuncs.c
@@ -856,6 +856,10 @@ int LuaEscapeParam(lua_State *L) {
   return LuaCoder(L, EscapeParam);
 }
 
+int LuaUnescapeParam(lua_State *L) {
+  return LuaCoder(L, UnescapeParam);
+}
+
 int LuaEscapePath(lua_State *L) {
   return LuaCoder(L, EscapePath);
 }

--- a/tool/net/lfuncs.h
+++ b/tool/net/lfuncs.h
@@ -35,6 +35,7 @@ int LuaEscapeHtml(lua_State *);
 int LuaEscapeIp(lua_State *);
 int LuaEscapeLiteral(lua_State *);
 int LuaEscapeParam(lua_State *);
+int LuaUnescapeParam(lua_State *);
 int LuaEscapePass(lua_State *);
 int LuaEscapePath(lua_State *);
 int LuaEscapeSegment(lua_State *);


### PR DESCRIPTION
## Summary

Add `cosmo.UnescapeParam()` function to decode percent-encoded URL parameters.

This is the inverse of `EscapeParam()` and decodes:
- `%XX` hex sequences (e.g., `%20` → space)
- `+` as space (common in application/x-www-form-urlencoded)

## Changes

- Add `UnescapeParam()` C function in `net/http/unescapeparam.c`
- Add function declaration to `net/http/escape.h`
- Add Lua binding in `tool/net/lfuncs.c`
- Export as `cosmo.UnescapeParam()` in `tool/lua/lcosmo.c`
- Add C tests in `test/net/http/unescapeparam_test.c`
- Add Lua tests in `test/tool/net/lfuncs_test.lua`
- Add documentation in `tool/net/definitions.lua`

## Test plan

- [x] C tests pass: `make o//test/net/http/unescapeparam_test.runs`
- [ ] Lua tests pass: `make o//test/tool/net/lfuncs_test.lua.runs`

## Usage

```lua
local cosmo = require("cosmo")

-- Decode percent-encoded strings
cosmo.UnescapeParam("%3Fhello%26there")  -- "?hello&there"

-- Plus signs become spaces
cosmo.UnescapeParam("hello+world")  -- "hello world"

-- Round-trip with EscapeParam
cosmo.UnescapeParam(cosmo.EscapeParam("hello world!"))  -- "hello world!"
```

Closes whilp/cosmic#146