### PR TITLE
lua: add remove() method to zip appender

### DIFF
--- a/tool/lua/cosmo/zip/test_append.lua
+++ b/tool/lua/cosmo/zip/test_append.lua
@@ -167,6 +167,262 @@ assert(result == nil, "add on closed appender should fail")
 assert(err:match("closed"), "error should mention closed")
 
 --------------------------------------------------------------------------------
+-- Test remove existing entry
+--------------------------------------------------------------------------------
+
+local remove_zip = tmpdir .. "/remove_test.zip"
+writer = zip.open(remove_zip, "w")
+writer:add("keep.txt", "keep this")
+writer:add("remove_me.txt", "remove this")
+writer:add("also_keep.txt", "also keep")
+writer:close()
+
+appender = zip.open(remove_zip, "a")
+assert(appender, "should open for append")
+
+ok, err = appender:remove("remove_me.txt")
+assert(ok, "remove should succeed: " .. tostring(err))
+
+ok, err = appender:close()
+assert(ok, "close after remove should succeed: " .. tostring(err))
+
+reader = zip.open(remove_zip)
+entries = reader:list()
+assert(#entries == 2, "should have 2 entries after remove, got " .. #entries)
+
+entry_set = {}
+for _, name in ipairs(entries) do
+  entry_set[name] = true
+end
+assert(entry_set["keep.txt"], "keep.txt should still exist")
+assert(entry_set["also_keep.txt"], "also_keep.txt should still exist")
+assert(not entry_set["remove_me.txt"], "remove_me.txt should be gone")
+
+assert(reader:read("keep.txt") == "keep this", "keep.txt content should be preserved")
+assert(reader:read("also_keep.txt") == "also keep", "also_keep.txt content should be preserved")
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove then add same name (replace pattern)
+--------------------------------------------------------------------------------
+
+local replace_zip = tmpdir .. "/replace_test.zip"
+writer = zip.open(replace_zip, "w")
+writer:add("config.txt", "old config")
+writer:add("data.txt", "data file")
+writer:close()
+
+appender = zip.open(replace_zip, "a")
+assert(appender, "should open for append")
+
+ok, err = appender:remove("config.txt")
+assert(ok, "remove should succeed: " .. tostring(err))
+
+ok, err = appender:add("config.txt", "new config")
+assert(ok, "add after remove should succeed: " .. tostring(err))
+
+ok, err = appender:close()
+assert(ok, "close should succeed: " .. tostring(err))
+
+reader = zip.open(replace_zip)
+entries = reader:list()
+assert(#entries == 2, "should still have 2 entries, got " .. #entries)
+
+local config_content = reader:read("config.txt")
+assert(config_content == "new config", "config should have new content, got: " .. tostring(config_content))
+assert(reader:read("data.txt") == "data file", "data.txt should be preserved")
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove pending entry
+--------------------------------------------------------------------------------
+
+local remove_pending_zip = tmpdir .. "/remove_pending_test.zip"
+writer = zip.open(remove_pending_zip, "w")
+writer:add("existing.txt", "existing")
+writer:close()
+
+appender = zip.open(remove_pending_zip, "a")
+appender:add("new1.txt", "new content 1")
+appender:add("new2.txt", "new content 2")
+
+-- Remove a pending entry (not yet written to disk)
+ok, err = appender:remove("new1.txt")
+assert(ok, "remove pending entry should succeed: " .. tostring(err))
+
+ok, err = appender:close()
+assert(ok, "close should succeed: " .. tostring(err))
+
+reader = zip.open(remove_pending_zip)
+entries = reader:list()
+assert(#entries == 2, "should have 2 entries (existing + new2), got " .. #entries)
+
+entry_set = {}
+for _, name in ipairs(entries) do
+  entry_set[name] = true
+end
+assert(entry_set["existing.txt"], "existing.txt should be present")
+assert(entry_set["new2.txt"], "new2.txt should be present")
+assert(not entry_set["new1.txt"], "new1.txt should be gone")
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove non-existent entry
+--------------------------------------------------------------------------------
+
+appender = zip.open(remove_pending_zip, "a")
+
+result, err = appender:remove("nonexistent.txt")
+assert(result == nil, "removing non-existent entry should fail")
+assert(err:match("not found"), "error should mention not found")
+
+appender:close()
+
+--------------------------------------------------------------------------------
+-- Test remove on closed appender
+--------------------------------------------------------------------------------
+
+appender = zip.open(remove_pending_zip, "a")
+appender:close()
+
+result, err = appender:remove("test.txt")
+assert(result == nil, "remove on closed appender should fail")
+assert(err:match("closed"), "error should mention closed")
+
+--------------------------------------------------------------------------------
+-- Test remove all entries
+--------------------------------------------------------------------------------
+
+local remove_all_zip = tmpdir .. "/remove_all_test.zip"
+writer = zip.open(remove_all_zip, "w")
+writer:add("a.txt", "aaa")
+writer:add("b.txt", "bbb")
+writer:close()
+
+appender = zip.open(remove_all_zip, "a")
+appender:remove("a.txt")
+appender:remove("b.txt")
+appender:close()
+
+reader = zip.open(remove_all_zip)
+entries = reader:list()
+assert(#entries == 0, "should have 0 entries after removing all, got " .. #entries)
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove directory (recursive prefix removal)
+--------------------------------------------------------------------------------
+
+local remove_dir_zip = tmpdir .. "/remove_dir_test.zip"
+writer = zip.open(remove_dir_zip, "w")
+writer:add("root.txt", "root file")
+writer:add("subdir/a.txt", "aaa")
+writer:add("subdir/b.txt", "bbb")
+writer:add("subdir/nested/c.txt", "ccc")
+writer:add("other/d.txt", "ddd")
+writer:close()
+
+appender = zip.open(remove_dir_zip, "a")
+assert(appender, "should open for append")
+
+-- Remove entire subdir/ directory recursively
+ok, err = appender:remove("subdir/")
+assert(ok, "directory remove should succeed: " .. tostring(err))
+
+ok, err = appender:close()
+assert(ok, "close should succeed: " .. tostring(err))
+
+reader = zip.open(remove_dir_zip)
+entries = reader:list()
+assert(#entries == 2, "should have 2 entries after dir remove, got " .. #entries)
+
+entry_set = {}
+for _, name in ipairs(entries) do
+  entry_set[name] = true
+end
+assert(entry_set["root.txt"], "root.txt should still exist")
+assert(entry_set["other/d.txt"], "other/d.txt should still exist")
+assert(not entry_set["subdir/a.txt"], "subdir/a.txt should be gone")
+assert(not entry_set["subdir/b.txt"], "subdir/b.txt should be gone")
+assert(not entry_set["subdir/nested/c.txt"], "subdir/nested/c.txt should be gone")
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove directory with pending entries
+--------------------------------------------------------------------------------
+
+local remove_dir_pending_zip = tmpdir .. "/remove_dir_pending_test.zip"
+writer = zip.open(remove_dir_pending_zip, "w")
+writer:add("existing.txt", "existing")
+writer:add("dir/old.txt", "old file")
+writer:close()
+
+appender = zip.open(remove_dir_pending_zip, "a")
+appender:add("dir/new1.txt", "new 1")
+appender:add("dir/new2.txt", "new 2")
+appender:add("other.txt", "other")
+
+-- Remove dir/ should remove existing dir/old.txt AND pending dir/new1.txt, dir/new2.txt
+ok, err = appender:remove("dir/")
+assert(ok, "directory remove should succeed: " .. tostring(err))
+
+appender:close()
+
+reader = zip.open(remove_dir_pending_zip)
+entries = reader:list()
+assert(#entries == 2, "should have 2 entries, got " .. #entries)
+
+entry_set = {}
+for _, name in ipairs(entries) do
+  entry_set[name] = true
+end
+assert(entry_set["existing.txt"], "existing.txt should be present")
+assert(entry_set["other.txt"], "other.txt should be present")
+assert(not entry_set["dir/old.txt"], "dir/old.txt should be gone")
+assert(not entry_set["dir/new1.txt"], "dir/new1.txt should be gone")
+assert(not entry_set["dir/new2.txt"], "dir/new2.txt should be gone")
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove directory then add new entries in same directory
+--------------------------------------------------------------------------------
+
+local replace_dir_zip = tmpdir .. "/replace_dir_test.zip"
+writer = zip.open(replace_dir_zip, "w")
+writer:add("assets/logo.png", "old logo")
+writer:add("assets/style.css", "old style")
+writer:add("index.html", "index")
+writer:close()
+
+appender = zip.open(replace_dir_zip, "a")
+appender:remove("assets/")
+appender:add("assets/logo.png", "new logo")
+appender:add("assets/app.js", "new script")
+appender:close()
+
+reader = zip.open(replace_dir_zip)
+entries = reader:list()
+assert(#entries == 3, "should have 3 entries, got " .. #entries)
+
+assert(reader:read("index.html") == "index", "index.html should be preserved")
+assert(reader:read("assets/logo.png") == "new logo", "logo should have new content")
+assert(reader:read("assets/app.js") == "new script", "app.js should exist")
+
+local old_style = reader:read("assets/style.css")
+assert(old_style == nil, "style.css should be gone")
+reader:close()
+
+--------------------------------------------------------------------------------
+-- Test remove non-existent directory
+--------------------------------------------------------------------------------
+
+appender = zip.open(replace_dir_zip, "a")
+result, err = appender:remove("nonexistent/")
+assert(result == nil, "removing non-existent directory should fail")
+assert(err:match("not found"), "error should mention not found")
+appender:close()
+
+--------------------------------------------------------------------------------
 -- Cleanup
 --------------------------------------------------------------------------------
 

--- a/tool/net/lzip.c
+++ b/tool/net/lzip.c
@@ -91,6 +91,7 @@ struct LuaZipAppender {
   uint8_t **pending_data;  // compressed data for pending entries
   int level;
   int64_t max_file_size;
+  int dirty;               // nonzero if entries were removed
 };
 
 static struct LuaZipReader *GetZipReader(lua_State *L) {
@@ -1521,6 +1522,70 @@ static int LuaZipAppenderAdd(lua_State *L) {
   return 1;
 }
 
+// Returns true if entry name matches for removal.
+// If the pattern ends with '/', it matches any entry with that prefix
+// (recursive directory removal). Otherwise it matches exactly.
+static bool RemoveMatches(const char *entry_name, size_t entry_namelen,
+                          const char *pattern, size_t pattern_len,
+                          bool is_dir_pattern) {
+  if (is_dir_pattern) {
+    return entry_namelen >= pattern_len &&
+           !memcmp(entry_name, pattern, pattern_len);
+  } else {
+    return entry_namelen == pattern_len &&
+           !memcmp(entry_name, pattern, pattern_len);
+  }
+}
+
+// appender:remove(name) -> true | nil, error
+// Removes entries by name from the appender (existing or pending).
+// If name ends with '/', removes all entries with that directory prefix.
+// The local file data for removed existing entries remains as dead space
+// in the archive; only the central directory reference is removed.
+static int LuaZipAppenderRemove(lua_State *L) {
+  struct LuaZipAppender *a = GetZipAppender(L);
+  size_t namelen;
+  const char *name = luaL_checklstring(L, 2, &namelen);
+
+  if (a->fd == -1)
+    return ZipError(L, "zip appender is closed");
+
+  bool is_dir = namelen > 0 && name[namelen - 1] == '/';
+  int removed = 0;
+
+  // Check existing entries (iterate backwards for safe swap-removal)
+  for (size_t i = a->existing_count; i-- > 0;) {
+    if (RemoveMatches(a->existing[i].name, a->existing[i].namelen,
+                      name, namelen, is_dir)) {
+      free(a->existing[i].name);
+      a->existing[i] = a->existing[--a->existing_count];
+      removed++;
+      if (!is_dir) break;
+    }
+  }
+
+  // Check pending entries (iterate backwards for safe swap-removal)
+  for (size_t i = a->pending_count; i-- > 0;) {
+    if (RemoveMatches(a->pending[i].name, a->pending[i].namelen,
+                      name, namelen, is_dir)) {
+      free(a->pending[i].name);
+      free(a->pending_data[i]);
+      size_t last = --a->pending_count;
+      a->pending[i] = a->pending[last];
+      a->pending_data[i] = a->pending_data[last];
+      removed++;
+      if (!is_dir) break;
+    }
+  }
+
+  if (removed == 0)
+    return ZipError(L, "entry not found");
+
+  a->dirty = 1;
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
 // appender:close() -> true | nil, error
 static int LuaZipAppenderClose(lua_State *L) {
   struct LuaZipAppender *a = GetZipAppender(L);
@@ -1530,8 +1595,8 @@ static int LuaZipAppenderClose(lua_State *L) {
     return 1;
   }
 
-  // If no pending entries, just close
-  if (a->pending_count == 0) {
+  // If no pending entries and nothing was removed, just close
+  if (a->pending_count == 0 && !a->dirty) {
     AppenderCleanup(a);
     lua_pushboolean(L, 1);
     return 1;
@@ -1681,6 +1746,7 @@ static const luaL_Reg kLuaZipAppenderMeta[] = {
 static const luaL_Reg kLuaZipAppenderMethods[] = {
     {"close", LuaZipAppenderClose},
     {"add", LuaZipAppenderAdd},
+    {"remove", LuaZipAppenderRemove},
     {0},
 };
 


### PR DESCRIPTION
## Summary
- Add `appender:remove(name)` for removing entries from zip archives
- Support exact name matching and recursive directory removal (when name ends with `/`)
- Enable simple remove+add pattern for replacing entries without rebuilding the entire archive

## Test plan
- Run `tool/lua/cosmo/zip/test_append.lua` to verify remove functionality