### PR TITLE
fetch: add streaming HTTP fetch API (FetchStream)

### DIFF
--- a/test/tool/net/BUILD.mk
+++ b/test/tool/net/BUILD.mk
@@ -88,6 +88,9 @@ o/$(MODE)/test/tool/net/redbean_test.runs:			\
 o/$(MODE)/test/tool/net/lfetch_test.lua.runs:			\
 		private .PLEDGE = stdio rpath inet proc
 
+o/$(MODE)/test/tool/net/lfetchstream_test.lua.runs:		\
+		private .PLEDGE = stdio rpath inet proc
+
 o/$(MODE)/test/tool/net/sqlite_test.runs:			\
 		private .PLEDGE = flock
 

--- a/test/tool/net/lfetchstream_test.lua
+++ b/test/tool/net/lfetchstream_test.lua
@@ -1,0 +1,389 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Test cases for FetchStream (streaming fetch)
+-- Uses local test servers to verify streaming behavior
+
+local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
+local FetchStream = cosmo.FetchStream
+
+-- Helper: Create a simple TCP server
+local function create_test_server()
+    local sock = assert(unix.socket(unix.AF_INET, unix.SOCK_STREAM, 0))
+    assert(unix.setsockopt(sock, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1))
+    assert(unix.bind(sock, cosmo.ParseIp("127.0.0.1"), 0))
+    assert(unix.listen(sock, 5))
+    local ip, port = unix.getsockname(sock)
+    return sock, port
+end
+
+-- Helper: Accept one connection, read request headers, then send custom response
+local function accept_and_respond(server_sock, response_fn, timeout_ms)
+    timeout_ms = timeout_ms or 5000
+    unix.setsockopt(server_sock, unix.SOL_SOCKET, unix.SO_RCVTIMEO,
+                    timeout_ms // 1000, (timeout_ms % 1000) * 1000)
+    local client, err = unix.accept(server_sock)
+    if not client then
+        return nil, "accept failed: " .. tostring(err)
+    end
+    local request = ""
+    while true do
+        local data = unix.read(client, 4096)
+        if not data or #data == 0 then break end
+        request = request .. data
+        if request:find("\r\n\r\n") then break end
+    end
+    response_fn(client)
+    unix.close(client)
+    return request
+end
+
+-- Test: Basic streaming fetch with Content-Length body
+function test_stream_content_length()
+    local server, port = create_test_server()
+    local body_data = "Hello, streaming world!"
+    local response = "HTTP/1.1 200 OK\r\n" ..
+                     "Content-Length: " .. #body_data .. "\r\n" ..
+                     "Content-Type: text/plain\r\n" ..
+                     "Connection: close\r\n" ..
+                     "\r\n" ..
+                     body_data
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, response)
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/test", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200, got: " .. tostring(status))
+    assert(reader, "expected reader object")
+    assert(tostring(reader):find("FetchReader"), "expected FetchReader tostring")
+
+    -- Read all chunks
+    local chunks = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then
+            if err then error("read error: " .. err) end
+            break
+        end
+        table.insert(chunks, chunk)
+    end
+    reader:close()
+
+    local full_body = table.concat(chunks)
+    assert(full_body == body_data,
+           "expected '" .. body_data .. "', got: '" .. full_body .. "'")
+
+    unix.wait(pid)
+    print("test_stream_content_length: PASS")
+end
+
+-- Test: Streaming fetch with chunked transfer encoding
+function test_stream_chunked()
+    local server, port = create_test_server()
+    local chunk1 = "Hello, "
+    local chunk2 = "chunked "
+    local chunk3 = "world!"
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            -- Send headers
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Transfer-Encoding: chunked\r\n" ..
+                              "Content-Type: text/plain\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n")
+            -- Send chunks with small delays
+            unix.write(client, string.format("%x\r\n%s\r\n", #chunk1, chunk1))
+            unix.nanosleep(0, 50000000) -- 50ms
+            unix.write(client, string.format("%x\r\n%s\r\n", #chunk2, chunk2))
+            unix.nanosleep(0, 50000000)
+            unix.write(client, string.format("%x\r\n%s\r\n", #chunk3, chunk3))
+            -- Final chunk
+            unix.write(client, "0\r\n\r\n")
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/chunked", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200, got: " .. tostring(status))
+
+    -- Read all chunks
+    local chunks = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then
+            if err then error("read error: " .. err) end
+            break
+        end
+        if #chunk > 0 then
+            table.insert(chunks, chunk)
+        end
+    end
+    reader:close()
+
+    local full_body = table.concat(chunks)
+    assert(full_body == "Hello, chunked world!",
+           "expected 'Hello, chunked world!', got: '" .. full_body .. "'")
+
+    unix.wait(pid)
+    print("test_stream_chunked: PASS")
+end
+
+-- Test: Streaming fetch with no Content-Length (read until close)
+function test_stream_until_close()
+    local server, port = create_test_server()
+    local body_data = "streaming until connection close"
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Content-Type: text/plain\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n" ..
+                              body_data)
+            -- Connection close triggers EOF
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/close", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200, got: " .. tostring(status))
+
+    local chunks = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then
+            if err then error("read error: " .. err) end
+            break
+        end
+        if #chunk > 0 then
+            table.insert(chunks, chunk)
+        end
+    end
+    reader:close()
+
+    local full_body = table.concat(chunks)
+    assert(full_body == body_data,
+           "expected '" .. body_data .. "', got: '" .. full_body .. "'")
+
+    unix.wait(pid)
+    print("test_stream_until_close: PASS")
+end
+
+-- Test: Reader close is idempotent
+function test_reader_close_idempotent()
+    local server, port = create_test_server()
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Content-Length: 2\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n" ..
+                              "OK")
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/test", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200)
+
+    -- Read the body
+    reader:read()
+    -- Close multiple times - should not error
+    reader:close()
+    reader:close()
+    reader:close()
+
+    -- Read after close should return error
+    local chunk, err = reader:read()
+    assert(chunk == nil, "expected nil after close")
+    assert(err, "expected error message after close")
+
+    unix.wait(pid)
+    print("test_reader_close_idempotent: PASS")
+end
+
+-- Test: FetchStream returns nil on error (same as Fetch)
+function test_stream_error_handling()
+    local status, err = FetchStream("invalid://bad-scheme")
+    assert(status == nil, "expected nil for bad scheme")
+    assert(type(err) == "string", "expected error string")
+    print("test_stream_error_handling: PASS")
+end
+
+-- Test: 204 No Content returns closed reader
+function test_stream_no_content()
+    local server, port = create_test_server()
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 204 No Content\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n")
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/no-content", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 204, "expected 204, got: " .. tostring(status))
+    assert(reader, "expected reader object")
+
+    -- Reader should be immediately closed (no body)
+    local chunk, err = reader:read()
+    assert(chunk == nil, "expected nil from closed reader")
+    reader:close()
+
+    unix.wait(pid)
+    print("test_stream_no_content: PASS")
+end
+
+-- Test: SSE-like streaming (chunked with data: lines)
+function test_stream_sse_pattern()
+    local server, port = create_test_server()
+    local events = {
+        "data: {\"type\": \"start\"}\n\n",
+        "data: {\"type\": \"delta\", \"text\": \"Hello\"}\n\n",
+        "data: {\"type\": \"delta\", \"text\": \" World\"}\n\n",
+        "data: {\"type\": \"stop\"}\n\n",
+    }
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Transfer-Encoding: chunked\r\n" ..
+                              "Content-Type: text/event-stream\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n")
+            for _, event in ipairs(events) do
+                unix.write(client, string.format("%x\r\n%s\r\n", #event, event))
+                unix.nanosleep(0, 20000000) -- 20ms between events
+            end
+            unix.write(client, "0\r\n\r\n")
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/sse", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200, got: " .. tostring(status))
+    assert(headers["Content-Type"] == "text/event-stream",
+           "expected text/event-stream content type")
+
+    -- Read and parse SSE events
+    local buffer = ""
+    local parsed_events = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then
+            if err then error("read error: " .. err) end
+            break
+        end
+        buffer = buffer .. chunk
+        -- Parse complete events (separated by \n\n)
+        while true do
+            local event_end = buffer:find("\n\n")
+            if not event_end then break end
+            local event = buffer:sub(1, event_end + 1)
+            buffer = buffer:sub(event_end + 2)
+            if event:match("^data: ") then
+                table.insert(parsed_events, event:match("^data: (.-)%s*$"))
+            end
+        end
+    end
+    reader:close()
+
+    assert(#parsed_events == 4,
+           "expected 4 SSE events, got: " .. #parsed_events)
+    assert(parsed_events[1]:find('"start"'),
+           "expected start event")
+    assert(parsed_events[4]:find('"stop"'),
+           "expected stop event")
+
+    unix.wait(pid)
+    print("test_stream_sse_pattern: PASS")
+end
+
+local function main()
+    local tests = {
+        test_stream_content_length,
+        test_stream_chunked,
+        test_stream_until_close,
+        test_reader_close_idempotent,
+        test_stream_error_handling,
+        test_stream_no_content,
+        test_stream_sse_pattern,
+    }
+
+    local passed = 0
+    local failed = 0
+
+    for _, test in ipairs(tests) do
+        local ok, err = pcall(test)
+        if ok then
+            passed = passed + 1
+        else
+            failed = failed + 1
+            print("FAILED: " .. tostring(err))
+        end
+    end
+
+    print(string.format("\nResults: %d passed, %d failed", passed, failed))
+    if failed > 0 then
+        error("Some tests failed")
+    end
+end
+
+main()

--- a/test/tool/net/lfetchstream_test.lua
+++ b/test/tool/net/lfetchstream_test.lua
@@ -16,15 +16,17 @@
 -- Test cases for FetchStream (streaming fetch)
 -- Uses local test servers to verify streaming behavior
 
+-- Use FetchStream from redbean globals or cosmo module
 local cosmo = require("cosmo")
-local unix = require("cosmo.unix")
-local FetchStream = cosmo.FetchStream
+local FetchStream = FetchStream or cosmo.FetchStream
+local ParseIp = ParseIp or cosmo.ParseIp
+local unix = unix or require("unix")
 
 -- Helper: Create a simple TCP server
 local function create_test_server()
     local sock = assert(unix.socket(unix.AF_INET, unix.SOCK_STREAM, 0))
     assert(unix.setsockopt(sock, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1))
-    assert(unix.bind(sock, cosmo.ParseIp("127.0.0.1"), 0))
+    assert(unix.bind(sock, ParseIp("127.0.0.1"), 0))
     assert(unix.listen(sock, 5))
     local ip, port = unix.getsockname(sock)
     return sock, port

--- a/test/tool/net/lfetchstream_test.lua
+++ b/test/tool/net/lfetchstream_test.lua
@@ -358,6 +358,190 @@ function test_stream_sse_pattern()
     print("test_stream_sse_pattern: PASS")
 end
 
+-- Test: Invalid chunk size (non-hex characters)
+function test_stream_chunked_invalid_size()
+    local server, port = create_test_server()
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Transfer-Encoding: chunked\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n" ..
+                              "XYZ\r\n")  -- invalid: non-hex chunk size
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/bad-chunk", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200")
+
+    -- Reading should eventually fail due to invalid chunk encoding
+    local chunk, err = reader:read()
+    -- Either returns nil with error, or empty string, or the invalid data
+    -- The key is that we don't crash
+    reader:close()
+
+    unix.wait(pid)
+    print("test_stream_chunked_invalid_size: PASS")
+end
+
+-- Test: Missing CRLF after chunk data
+function test_stream_chunked_missing_crlf()
+    local server, port = create_test_server()
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Transfer-Encoding: chunked\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n" ..
+                              "5\r\nHello")  -- missing trailing \r\n
+            -- Connection closes immediately
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/missing-crlf", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200")
+
+    -- Try to read - may get partial data or error
+    local chunks = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then break end
+        if #chunk > 0 then table.insert(chunks, chunk) end
+    end
+    reader:close()
+
+    -- We should have gotten some data or an error, but not crashed
+    unix.wait(pid)
+    print("test_stream_chunked_missing_crlf: PASS")
+end
+
+-- Test: Incomplete terminator (0\r\n without final \r\n)
+function test_stream_chunked_incomplete_terminator()
+    local server, port = create_test_server()
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Transfer-Encoding: chunked\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n" ..
+                              "5\r\nHello\r\n" ..
+                              "0\r\n")  -- missing final \r\n
+            -- Connection closes before final CRLF
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/incomplete", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200")
+
+    -- Read until EOF or error
+    local chunks = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then break end
+        if #chunk > 0 then table.insert(chunks, chunk) end
+    end
+    reader:close()
+
+    -- Should have received "Hello" even if the terminator was incomplete
+    local body = table.concat(chunks)
+    assert(body == "Hello" or body == "",
+           "expected 'Hello' or empty, got: '" .. body .. "'")
+
+    unix.wait(pid)
+    print("test_stream_chunked_incomplete_terminator: PASS")
+end
+
+-- Test: Overflow chunk size (exceeds size_t)
+function test_stream_chunked_overflow_size()
+    local server, port = create_test_server()
+
+    local pid = unix.fork()
+    if pid == 0 then
+        accept_and_respond(server, function(client)
+            unix.write(client, "HTTP/1.1 200 OK\r\n" ..
+                              "Transfer-Encoding: chunked\r\n" ..
+                              "Connection: close\r\n" ..
+                              "\r\n" ..
+                              "10000000000000001\r\n")  -- overflow size
+        end)
+        unix.close(server)
+        os.exit(0)
+    end
+
+    unix.close(server)
+    local status, headers, reader = FetchStream("http://127.0.0.1:" .. port .. "/overflow", {
+        proxy = "http://127.0.0.1:" .. port
+    })
+
+    assert(status == 200, "expected 200")
+
+    -- Reading should fail with error (not hang or crash)
+    local chunk, err = reader:read()
+    -- Should get nil with error, or empty result
+    reader:close()
+
+    unix.wait(pid)
+    print("test_stream_chunked_overflow_size: PASS")
+end
+
+-- Test: HTTPS streaming (uses external service)
+function test_stream_https()
+    -- Test with a real HTTPS endpoint that supports streaming
+    local status, headers, reader = FetchStream("https://httpbin.org/stream/3")
+    if not status then
+        -- Network may not be available, skip test
+        print("test_stream_https: SKIP (no network: " .. tostring(headers) .. ")")
+        return
+    end
+    assert(status == 200, "expected 200, got: " .. tostring(status))
+    assert(reader, "expected reader object")
+
+    -- Read all chunks
+    local chunks = {}
+    while true do
+        local chunk, err = reader:read()
+        if not chunk then
+            if err then error("read error: " .. err) end
+            break
+        end
+        if #chunk > 0 then table.insert(chunks, chunk) end
+    end
+    reader:close()
+
+    local body = table.concat(chunks)
+    assert(#body > 0, "expected response body")
+    -- httpbin.org/stream/3 returns 3 JSON objects
+    local count = 0
+    for _ in body:gmatch('"id":') do count = count + 1 end
+    assert(count == 3, "expected 3 JSON objects, got: " .. count)
+
+    print("test_stream_https: PASS")
+end
+
 local function main()
     local tests = {
         test_stream_content_length,
@@ -367,6 +551,11 @@ local function main()
         test_stream_error_handling,
         test_stream_no_content,
         test_stream_sse_pattern,
+        test_stream_chunked_invalid_size,
+        test_stream_chunked_missing_crlf,
+        test_stream_chunked_incomplete_terminator,
+        test_stream_chunked_overflow_size,
+        test_stream_https,
     }
 
     local passed = 0

--- a/tool/lua/lcosmo.c
+++ b/tool/lua/lcosmo.c
@@ -261,6 +261,7 @@ static const luaL_Reg kCosmoFuncs[] = {
     {"Sha512", LuaSha512},
     {"Curve25519", LuaCurve25519},
     {"Fetch", LuaFetch},
+    {"FetchStream", LuaFetchStream},
     {NULL, NULL}
 };
 // clang-format on
@@ -277,6 +278,7 @@ static void register_submodule(lua_State *L, const char *name) {
 int luaopen_cosmo(lua_State *L) {
   /* initialize fetch SSL state */
   LuaInitFetch();
+  LuaInitFetchReader(L);
 
   luaL_newlib(L, kCosmoFuncs);
 

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -1156,6 +1156,19 @@ function EvadeDragnetSurveillance(bool) end
 ---@overload fun(url:string, body?: string|{ headers: table<string,string>, method: string, body: string, maxredirects?: integer, keepalive: boolean?, proxy: string?, maxresponse: integer?, resettls: boolean? }): nil, error: string
 function Fetch(url, body) end
 
+--- Sends an HTTP/HTTPS request and returns a streaming reader for the response body.
+--- Useful for Server-Sent Events (SSE), large downloads, or processing data incrementally.
+---@param url string The URL to fetch
+---@param options? { headers: table<string,string>, method: string, body: string, maxredirects?: integer, followredirect?: boolean, proxy: string? } Request options
+---@return integer status, table<string,string> headers, FetchReader reader
+---@nodiscard
+---@overload fun(url:string, options?: table): nil, error: string
+function FetchStream(url, options) end
+
+---@class FetchReader
+---@field read fun(self: FetchReader): string?, string? Returns next chunk, or nil on EOF, or nil,error on failure
+---@field close fun(self: FetchReader) Closes the reader and releases resources (idempotent)
+
 --- Converts UNIX timestamp to an RFC1123 string that looks like this:
 --- `Mon, 29 Mar 2021 15:37:13 GMT`. See `formathttpdatetime.c`.
 ---@param seconds integer

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -395,7 +395,8 @@ int LuaFetch(lua_State *L) {
    */
   if (usingssl && proxyhost) {
     char *connectreq = 0;
-    char connectbuf[1024];
+    struct Buffer connectbuf = {0};
+    struct HttpMessage connectmsg;
     ssize_t connectrc;
     appendf(&connectreq,
             "CONNECT %s:%s HTTP/1.1\r\n"
@@ -415,17 +416,52 @@ int LuaFetch(lua_State *L) {
         return LuaNilError(L, "proxy CONNECT write error: %s", strerror(errno));
       }
     }
-    // Read proxy response (simple parsing - just check for "200")
-    if ((connectrc = READ(sock, connectbuf, sizeof(connectbuf) - 1)) <= 0) {
-      close(sock);
-      return LuaNilError(L, "proxy CONNECT read error: %s", strerror(errno));
+    // Read and parse proxy CONNECT response properly
+    InitHttpMessage(&connectmsg, kHttpResponse);
+    for (;;) {
+      if (connectbuf.n == connectbuf.c) {
+        char *newp;
+        connectbuf.c += 256;
+        if (connectbuf.c > 8192) {
+          DestroyHttpMessage(&connectmsg);
+          free(connectbuf.p);
+          close(sock);
+          return LuaNilError(L, "proxy CONNECT response too large");
+        }
+        if (!(newp = realloc(connectbuf.p, connectbuf.c))) {
+          DestroyHttpMessage(&connectmsg);
+          free(connectbuf.p);
+          close(sock);
+          return LuaNilError(L, "out of memory");
+        }
+        connectbuf.p = newp;
+      }
+      if ((connectrc = READ(sock, connectbuf.p + connectbuf.n,
+                            connectbuf.c - connectbuf.n)) <= 0) {
+        DestroyHttpMessage(&connectmsg);
+        free(connectbuf.p);
+        close(sock);
+        return LuaNilError(L, "proxy CONNECT read error: %s", strerror(errno));
+      }
+      connectbuf.n += connectrc;
+      rc = ParseHttpMessage(&connectmsg, connectbuf.p, connectbuf.n, SHRT_MAX);
+      if (rc == -1) {
+        DestroyHttpMessage(&connectmsg);
+        free(connectbuf.p);
+        close(sock);
+        return LuaNilError(L, "proxy CONNECT malformed response");
+      }
+      if (rc > 0) break;  // complete
     }
-    connectbuf[connectrc] = '\0';
-    // Check for successful tunnel establishment (HTTP/1.x 200)
-    if (!strstr(connectbuf, " 200 ")) {
+    if (connectmsg.status != 200) {
+      int status = connectmsg.status;
+      DestroyHttpMessage(&connectmsg);
+      free(connectbuf.p);
       close(sock);
-      return LuaNilError(L, "proxy CONNECT failed: %.64s", connectbuf);
+      return LuaNilError(L, "proxy CONNECT failed: HTTP %d", status);
     }
+    DestroyHttpMessage(&connectmsg);
+    free(connectbuf.p);
     DEBUGF("(ftch) CONNECT tunnel established through proxy");
   }
 

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -1100,6 +1100,40 @@ FUNCTIONS
           redirect is followed. Note that if these (method/body) values are
           provided as table fields, they will be modified in place.
 
+  FetchStream(url:str[,{method=value:str,body=value:str,headers=table,...}])
+      ├─→ status:int, {header:str=value:str,...}, reader:FetchReader
+      └─→ nil, error:str
+          Sends an HTTP/HTTPS request and returns a streaming reader for the
+          response body. This is useful for Server-Sent Events (SSE), large
+          downloads, or any case where you want to process data incrementally
+          rather than buffering the entire response in memory.
+
+          The options table accepts the same fields as Fetch():
+            - method (default = "GET"): sets the request method
+            - body (default = ""): sets the request body
+            - headers: sets request headers
+            - followredirect (default = true): follow redirects
+            - maxredirects (default = 5): maximum number of redirects
+
+          The returned FetchReader object has these methods:
+            - reader:read() → chunk:str or nil,error:str
+              Returns the next chunk of data, or nil on EOF, or nil,error
+              on failure. May return empty string if chunk framing was
+              received but no payload data is available yet.
+            - reader:close()
+              Closes the reader and releases resources. Idempotent.
+
+          Example usage:
+            local status, headers, reader = FetchStream(url)
+            if status == 200 then
+              while true do
+                local chunk, err = reader:read()
+                if not chunk then break end
+                if #chunk > 0 then process(chunk) end
+              end
+              reader:close()
+            end
+
   FormatHttpDateTime(seconds:int) → rfc1123:str
           Converts UNIX timestamp to an RFC1123 string that looks like this:
           Mon, 29 Mar 2021 15:37:13 GMT. See formathttpdatetime.c.

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -323,6 +323,7 @@ typedef struct FetchReader {
   int sock;
   bool closed;
   bool usingssl;
+  bool stream_complete;     // true when body is fully read (return nil on next read)
   int body_state;           // kHttpClientStateBody/Lengthed/Chunked
   size_t content_length;    // for lengthed bodies
   size_t bytes_read;        // body bytes returned so far
@@ -374,6 +375,12 @@ static int LuaFetchReaderRead(lua_State *L) {
     return 2;
   }
 
+  // Check if stream was already completed (return EOF)
+  if (r->stream_complete) {
+    lua_pushnil(L);
+    return 1;
+  }
+
   // For lengthed bodies, check if we already got everything
   if (r->body_state == kHttpClientStateBodyLengthed &&
       r->bytes_read >= r->content_length) {
@@ -400,14 +407,19 @@ static int LuaFetchReaderRead(lua_State *L) {
       // paylen is only set when uc>0 (complete), so use u.j always.
       size_t decoded = r->u.j;
       if (uc > 0) {
-        // Chunked encoding complete
+        // Chunked encoding complete - mark stream as done
+        r->stream_complete = true;
         if (decoded > 0) {
+          // Return the decoded data; next read will return EOF
           lua_pushlstring(L, r->buf.p + r->buf_pos, decoded);
           r->bytes_read += decoded;
+          r->buf_pos = r->buf.n;
+          return 1;
         }
-        FetchReaderClose(r);
+        // No data in final chunk, return EOF immediately
         r->buf_pos = r->buf.n;
-        return decoded > 0 ? 1 : (lua_pushnil(L), 1);
+        lua_pushnil(L);
+        return 1;
       }
       if (decoded > 0) {
         lua_pushlstring(L, r->buf.p + r->buf_pos, decoded);
@@ -491,12 +503,16 @@ static int LuaFetchReaderRead(lua_State *L) {
     size_t decoded = r->u.j;
     if (uc > 0) {
       // Chunked encoding complete (final chunk + trailers received)
+      r->stream_complete = true;
       if (decoded > 0) {
+        // Return the decoded data; next read will return EOF
         lua_pushlstring(L, readbuf, decoded);
         r->bytes_read += decoded;
+        return 1;
       }
-      FetchReaderClose(r);
-      return decoded > 0 ? 1 : (lua_pushnil(L), 1);
+      // No data in final chunk, return EOF immediately
+      lua_pushnil(L);
+      return 1;
     }
     if (decoded > 0) {
       lua_pushlstring(L, readbuf, decoded);
@@ -518,7 +534,7 @@ static int LuaFetchReaderRead(lua_State *L) {
   r->bytes_read += len;
   if (r->body_state == kHttpClientStateBodyLengthed &&
       r->bytes_read >= r->content_length) {
-    FetchReaderClose(r);
+    r->stream_complete = true;
   }
   return 1;
 }

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -331,9 +331,8 @@ typedef struct FetchReader {
   struct Buffer buf;        // read buffer
   size_t buf_pos;           // current read position in buffer (body data)
 #ifndef UNSECURE
-  mbedtls_ssl_context sslctx;
+  mbedtls_ssl_context *sslctx;  // heap-allocated, owned by reader
   struct TlsBio *bio;
-  bool sslctx_initialized;
 #endif
 } FetchReader;
 
@@ -345,9 +344,10 @@ static void FetchReaderClose(FetchReader *r) {
   if (r->closed) return;
   r->closed = true;
 #ifndef UNSECURE
-  if (r->sslctx_initialized) {
-    mbedtls_ssl_free(&r->sslctx);
-    r->sslctx_initialized = false;
+  if (r->sslctx) {
+    mbedtls_ssl_free(r->sslctx);
+    free(r->sslctx);
+    r->sslctx = NULL;
   }
   if (r->bio) {
     free(r->bio);
@@ -446,7 +446,7 @@ static int LuaFetchReaderRead(lua_State *L) {
   char readbuf[16384];
 #ifndef UNSECURE
   if (r->usingssl) {
-    rc = mbedtls_ssl_read(&r->sslctx, (unsigned char *)readbuf,
+    rc = mbedtls_ssl_read(r->sslctx, (unsigned char *)readbuf,
                           sizeof(readbuf));
     if (rc == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || rc == 0) {
       // EOF
@@ -602,8 +602,7 @@ int LuaFetchStream(lua_State *L) {
   char *proxyauthhdr = 0;
   char *request;
   struct TlsBio *bio;
-  mbedtls_ssl_context sslctx;
-  bool sslctx_initialized = false;
+  mbedtls_ssl_context *sslctx = NULL;
   struct addrinfo *addr;
   struct Buffer inbuf;
   struct HttpMessage msg;
@@ -934,18 +933,24 @@ int LuaFetchStream(lua_State *L) {
   // ---- TLS handshake ----
   bio = NULL;
   if (usingssl) {
-    mbedtls_ssl_init(&sslctx);
-    sslctx_initialized = true;
-    if ((ret = mbedtls_ssl_setup(&sslctx, &confcli)) != 0) {
-      mbedtls_ssl_free(&sslctx);
+    sslctx = malloc(sizeof(*sslctx));
+    if (!sslctx) {
+      close(sock);
+      return LuaNilError(L, "out of memory");
+    }
+    mbedtls_ssl_init(sslctx);
+    if ((ret = mbedtls_ssl_setup(sslctx, &confcli)) != 0) {
+      mbedtls_ssl_free(sslctx);
+      free(sslctx);
       close(sock);
       return LuaNilTlsError(L, "ssl_setup", ret);
     }
     if (!evadedragnetsurveillance)
-      mbedtls_ssl_set_hostname(&sslctx, host);
+      mbedtls_ssl_set_hostname(sslctx, host);
     bio = malloc(sizeof(struct TlsBio));
     if (!bio) {
-      mbedtls_ssl_free(&sslctx);
+      mbedtls_ssl_free(sslctx);
+      free(sslctx);
       close(sock);
       return LuaNilError(L, "out of memory");
     }
@@ -953,8 +958,8 @@ int LuaFetchStream(lua_State *L) {
     bio->a = 0;
     bio->b = 0;
     bio->c = -1;
-    mbedtls_ssl_set_bio(&sslctx, bio, TlsSend, 0, TlsRecvImpl);
-    while ((ret = mbedtls_ssl_handshake(&sslctx))) {
+    mbedtls_ssl_set_bio(sslctx, bio, TlsSend, 0, TlsRecvImpl);
+    while ((ret = mbedtls_ssl_handshake(sslctx))) {
       switch (ret) {
         case MBEDTLS_ERR_SSL_WANT_READ:
           break;
@@ -962,7 +967,8 @@ int LuaFetchStream(lua_State *L) {
           goto StreamVerifyFailed;
         default:
           free(bio);
-          mbedtls_ssl_free(&sslctx);
+          mbedtls_ssl_free(sslctx);
+          free(sslctx);
           close(sock);
           return LuaNilTlsError(L, "handshake", ret);
       }
@@ -975,13 +981,14 @@ int LuaFetchStream(lua_State *L) {
   for (i = 0; i < requestlen; i += rc) {
 #ifndef UNSECURE
     if (usingssl) {
-      rc = mbedtls_ssl_write(&sslctx, (unsigned char *)request + i,
+      rc = mbedtls_ssl_write(sslctx, (unsigned char *)request + i,
                              requestlen - i);
       if (rc <= 0) {
         if (rc == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED)
           goto StreamVerifyFailed;
         free(bio);
-        mbedtls_ssl_free(&sslctx);
+        mbedtls_ssl_free(sslctx);
+        free(sslctx);
         close(sock);
         return LuaNilTlsError(L, "write", rc);
       }
@@ -1011,7 +1018,7 @@ int LuaFetchStream(lua_State *L) {
     }
 #ifndef UNSECURE
     if (usingssl) {
-      if ((rc = mbedtls_ssl_read(&sslctx, (unsigned char *)inbuf.p + inbuf.n,
+      if ((rc = mbedtls_ssl_read(sslctx, (unsigned char *)inbuf.p + inbuf.n,
                                  inbuf.c - inbuf.n)) < 0) {
         if (rc == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
           rc = 0;
@@ -1019,7 +1026,8 @@ int LuaFetchStream(lua_State *L) {
           DestroyHttpMessage(&msg);
           free(inbuf.p);
           free(bio);
-          mbedtls_ssl_free(&sslctx);
+          mbedtls_ssl_free(sslctx);
+          free(sslctx);
           close(sock);
           return LuaNilTlsError(L, "read", rc);
         }
@@ -1030,7 +1038,7 @@ int LuaFetchStream(lua_State *L) {
       DestroyHttpMessage(&msg);
       free(inbuf.p);
 #ifndef UNSECURE
-      if (sslctx_initialized) { free(bio); mbedtls_ssl_free(&sslctx); }
+      if (sslctx) { free(bio); mbedtls_ssl_free(sslctx); free(sslctx); }
 #endif
       close(sock);
       return LuaNilError(L, "read error: %s", strerror(errno));
@@ -1099,7 +1107,7 @@ int LuaFetchStream(lua_State *L) {
               !memcasecmp(url.scheme.p, "http", 4)) {
             DestroyHttpMessage(&msg);
             free(inbuf.p);
-            if (sslctx_initialized) { free(bio); mbedtls_ssl_free(&sslctx); }
+            if (sslctx) { free(bio); mbedtls_ssl_free(sslctx); free(sslctx); }
             close(sock);
             return LuaNilError(L, "refusing HTTPS to HTTP redirect downgrade");
           }
@@ -1141,7 +1149,7 @@ int LuaFetchStream(lua_State *L) {
           DestroyHttpMessage(&msg);
           free(inbuf.p);
 #ifndef UNSECURE
-          if (sslctx_initialized) { free(bio); mbedtls_ssl_free(&sslctx); }
+          if (sslctx) { free(bio); mbedtls_ssl_free(sslctx); free(sslctx); }
 #endif
           close(sock);
           return LuaFetchStream(L);
@@ -1210,27 +1218,15 @@ StreamCreateReader: {
     }
 
 #ifndef UNSECURE
-    if (sslctx_initialized) {
-      // NOTE: We memcpy the ssl_context from stack to heap userdata.
-      // This works because:
-      // 1. We don't call mbedtls_ssl_free on the original (ownership transferred)
-      // 2. mbedtls_ssl_set_bio updates the only self-referential pointer (p_bio)
-      // 3. All other pointers (session, buffers) are to external heap allocations
-      // This pattern could break with future mbedtls versions if they add
-      // internal self-referential pointers.
-      memcpy(&reader->sslctx, &sslctx, sizeof(sslctx));
+    if (sslctx) {
+      // Transfer ownership of heap-allocated sslctx to reader
+      reader->sslctx = sslctx;
       reader->bio = bio;
-      reader->sslctx_initialized = true;
-      mbedtls_ssl_set_bio(&reader->sslctx, reader->bio, TlsSend, 0,
-                          TlsRecvImpl);
     }
 #endif
 
     // Stack: ..., status, headers, reader
-    // Don't free inbuf.p - reader owns it now
-    // Don't free bio - reader owns it now
-    // Don't close sock - reader owns it now
-    // Don't free sslctx - reader owns it now
+    // Ownership transferred to reader: inbuf.p, bio, sock, sslctx
     return 3;
   }
 
@@ -1241,9 +1237,10 @@ StreamFinishNoBody: {
     DestroyHttpMessage(&msg);
     free(inbuf.p);
 #ifndef UNSECURE
-    if (sslctx_initialized) {
+    if (sslctx) {
       free(bio);
-      mbedtls_ssl_free(&sslctx);
+      mbedtls_ssl_free(sslctx);
+      free(sslctx);
     }
 #endif
     close(sock);
@@ -1263,9 +1260,10 @@ StreamCleanupError:
   DestroyHttpMessage(&msg);
   free(inbuf.p);
 #ifndef UNSECURE
-  if (sslctx_initialized) {
+  if (sslctx) {
     free(bio);
-    mbedtls_ssl_free(&sslctx);
+    mbedtls_ssl_free(sslctx);
+    free(sslctx);
   }
 #endif
   close(sock);
@@ -1275,9 +1273,10 @@ StreamCleanupError:
 StreamVerifyFailed:
   LockInc(&shared->c.sslverifyfailed);
   {
-    uint32_t verify_result = sslctx.session_negotiate->verify_result;
+    uint32_t verify_result = sslctx->session_negotiate->verify_result;
     free(bio);
-    mbedtls_ssl_free(&sslctx);
+    mbedtls_ssl_free(sslctx);
+    free(sslctx);
     close(sock);
     return LuaNilTlsError(L, gc(DescribeSslVerifyFailure(verify_result)), ret);
   }

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -390,20 +390,28 @@ static int LuaFetchReaderRead(lua_State *L) {
       r->u.i = 0;
       r->u.j = 0;
       size_t paylen = 0;
-      rc = Unchunk(&r->u, r->buf.p + r->buf_pos, avail, &paylen);
-      if (rc == -1) {
+      int uc = Unchunk(&r->u, r->buf.p + r->buf_pos, avail, &paylen);
+      if (uc == -1) {
         lua_pushnil(L);
         lua_pushliteral(L, "unchunk error");
         return 2;
       }
-      if (paylen > 0) {
-        lua_pushlstring(L, r->buf.p + r->buf_pos, paylen);
-        r->bytes_read += paylen;
-        if (rc) {
-          // Unchunk complete - all data received
-          FetchReaderClose(r);
+      // Unchunk writes decoded data in-place; u.j has decoded byte count.
+      // paylen is only set when uc>0 (complete), so use u.j always.
+      size_t decoded = r->u.j;
+      if (uc > 0) {
+        // Chunked encoding complete
+        if (decoded > 0) {
+          lua_pushlstring(L, r->buf.p + r->buf_pos, decoded);
+          r->bytes_read += decoded;
         }
-        // Mark buffer as consumed
+        FetchReaderClose(r);
+        r->buf_pos = r->buf.n;
+        return decoded > 0 ? 1 : (lua_pushnil(L), 1);
+      }
+      if (decoded > 0) {
+        lua_pushlstring(L, r->buf.p + r->buf_pos, decoded);
+        r->bytes_read += decoded;
         r->buf_pos = r->buf.n;
         return 1;
       }
@@ -478,13 +486,21 @@ static int LuaFetchReaderRead(lua_State *L) {
       lua_pushliteral(L, "unchunk error");
       return 2;
     }
-    if (paylen > 0) {
-      lua_pushlstring(L, readbuf, paylen);
-      r->bytes_read += paylen;
-      if (uc) {
-        // Final chunk received
-        FetchReaderClose(r);
+    // Unchunk writes decoded data in-place; u.j has decoded byte count.
+    // paylen is only set when uc>0 (complete), so use u.j always.
+    size_t decoded = r->u.j;
+    if (uc > 0) {
+      // Chunked encoding complete (final chunk + trailers received)
+      if (decoded > 0) {
+        lua_pushlstring(L, readbuf, decoded);
+        r->bytes_read += decoded;
       }
+      FetchReaderClose(r);
+      return decoded > 0 ? 1 : (lua_pushnil(L), 1);
+    }
+    if (decoded > 0) {
+      lua_pushlstring(L, readbuf, decoded);
+      r->bytes_read += decoded;
       return 1;
     }
     // Got chunk framing but no data yet, try again

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -519,7 +519,10 @@ static int LuaFetchReaderRead(lua_State *L) {
       r->bytes_read += decoded;
       return 1;
     }
-    // Got chunk framing but no data yet, try again
+    // Got chunk framing but no payload data yet.
+    // NOTE: Returns empty string when chunk framing received but no payload data.
+    // Callers should handle empty chunks gracefully (e.g., skip if #chunk == 0).
+    // This can occur when chunk headers arrive separately from chunk data.
     lua_pushliteral(L, "");
     return 1;
   }
@@ -559,8 +562,7 @@ static int LuaFetchReaderTostring(lua_State *L) {
   if (r->closed) {
     lua_pushliteral(L, "FetchReader(closed)");
   } else {
-    lua_pushfstring(L, "FetchReader(fd=%d%s)", r->sock,
-                    r->usingssl ? ", ssl" : "");
+    lua_pushfstring(L, "FetchReader(%s)", r->usingssl ? "ssl" : "http");
   }
   return 1;
 }
@@ -861,7 +863,8 @@ int LuaFetchStream(lua_State *L) {
   // ---- HTTPS proxy CONNECT tunnel ----
   if (usingssl && proxyhost) {
     char *connectreq = 0;
-    char connectbuf[1024];
+    struct Buffer connectbuf = {0};
+    struct HttpMessage connectmsg;
     ssize_t connectrc;
     appendf(&connectreq,
             "CONNECT %s:%s HTTP/1.1\r\n"
@@ -880,15 +883,52 @@ int LuaFetchStream(lua_State *L) {
         return LuaNilError(L, "proxy CONNECT write error: %s", strerror(errno));
       }
     }
-    if ((connectrc = READ(sock, connectbuf, sizeof(connectbuf) - 1)) <= 0) {
-      close(sock);
-      return LuaNilError(L, "proxy CONNECT read error: %s", strerror(errno));
+    // Read and parse proxy CONNECT response properly
+    InitHttpMessage(&connectmsg, kHttpResponse);
+    for (;;) {
+      if (connectbuf.n == connectbuf.c) {
+        char *newp;
+        connectbuf.c += 256;
+        if (connectbuf.c > 8192) {
+          DestroyHttpMessage(&connectmsg);
+          free(connectbuf.p);
+          close(sock);
+          return LuaNilError(L, "proxy CONNECT response too large");
+        }
+        if (!(newp = realloc(connectbuf.p, connectbuf.c))) {
+          DestroyHttpMessage(&connectmsg);
+          free(connectbuf.p);
+          close(sock);
+          return LuaNilError(L, "out of memory");
+        }
+        connectbuf.p = newp;
+      }
+      if ((connectrc = READ(sock, connectbuf.p + connectbuf.n,
+                            connectbuf.c - connectbuf.n)) <= 0) {
+        DestroyHttpMessage(&connectmsg);
+        free(connectbuf.p);
+        close(sock);
+        return LuaNilError(L, "proxy CONNECT read error: %s", strerror(errno));
+      }
+      connectbuf.n += connectrc;
+      rc = ParseHttpMessage(&connectmsg, connectbuf.p, connectbuf.n, SHRT_MAX);
+      if (rc == -1) {
+        DestroyHttpMessage(&connectmsg);
+        free(connectbuf.p);
+        close(sock);
+        return LuaNilError(L, "proxy CONNECT malformed response");
+      }
+      if (rc > 0) break;  // complete
     }
-    connectbuf[connectrc] = '\0';
-    if (!strstr(connectbuf, " 200 ")) {
+    if (connectmsg.status != 200) {
+      int status = connectmsg.status;
+      DestroyHttpMessage(&connectmsg);
+      free(connectbuf.p);
       close(sock);
-      return LuaNilError(L, "proxy CONNECT failed: %.64s", connectbuf);
+      return LuaNilError(L, "proxy CONNECT failed: HTTP %d", status);
     }
+    DestroyHttpMessage(&connectmsg);
+    free(connectbuf.p);
   }
 
   // ---- TLS handshake ----
@@ -1171,10 +1211,16 @@ StreamCreateReader: {
 
 #ifndef UNSECURE
     if (sslctx_initialized) {
+      // NOTE: We memcpy the ssl_context from stack to heap userdata.
+      // This works because:
+      // 1. We don't call mbedtls_ssl_free on the original (ownership transferred)
+      // 2. mbedtls_ssl_set_bio updates the only self-referential pointer (p_bio)
+      // 3. All other pointers (session, buffers) are to external heap allocations
+      // This pattern could break with future mbedtls versions if they add
+      // internal self-referential pointers.
       memcpy(&reader->sslctx, &sslctx, sizeof(sslctx));
       reader->bio = bio;
       reader->sslctx_initialized = true;
-      // Rebind bio to copied context
       mbedtls_ssl_set_bio(&reader->sslctx, reader->bio, TlsSend, 0,
                           TlsRecvImpl);
     }

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -313,6 +313,900 @@ static void LuaResetFetchTlsState(void) {
 // Include the actual Fetch implementation
 #include "tool/net/fetch.inc"
 
+// ============================================================================
+// FetchStream: Streaming HTTP fetch that returns a reader object
+// ============================================================================
+
+#define FETCH_READER_MT "cosmo.FetchReader"
+
+typedef struct FetchReader {
+  int sock;
+  bool closed;
+  bool usingssl;
+  int body_state;           // kHttpClientStateBody/Lengthed/Chunked
+  size_t content_length;    // for lengthed bodies
+  size_t bytes_read;        // body bytes returned so far
+  struct HttpUnchunker u;   // chunked encoding state
+  struct Buffer buf;        // read buffer
+  size_t buf_pos;           // current read position in buffer (body data)
+#ifndef UNSECURE
+  mbedtls_ssl_context sslctx;
+  struct TlsBio *bio;
+  bool sslctx_initialized;
+#endif
+} FetchReader;
+
+static FetchReader *CheckFetchReader(lua_State *L) {
+  return (FetchReader *)luaL_checkudata(L, 1, FETCH_READER_MT);
+}
+
+static void FetchReaderClose(FetchReader *r) {
+  if (r->closed) return;
+  r->closed = true;
+#ifndef UNSECURE
+  if (r->sslctx_initialized) {
+    mbedtls_ssl_free(&r->sslctx);
+    r->sslctx_initialized = false;
+  }
+  if (r->bio) {
+    free(r->bio);
+    r->bio = NULL;
+  }
+#endif
+  if (r->sock >= 0) {
+    close(r->sock);
+    r->sock = -1;
+  }
+  free(r->buf.p);
+  r->buf.p = NULL;
+  r->buf.n = 0;
+  r->buf.c = 0;
+}
+
+// reader:read() -> string (chunk), or nil on EOF, or nil,err on error
+static int LuaFetchReaderRead(lua_State *L) {
+  FetchReader *r = CheckFetchReader(L);
+  ssize_t rc;
+
+  if (r->closed) {
+    lua_pushnil(L);
+    lua_pushliteral(L, "reader closed");
+    return 2;
+  }
+
+  // For lengthed bodies, check if we already got everything
+  if (r->body_state == kHttpClientStateBodyLengthed &&
+      r->bytes_read >= r->content_length) {
+    lua_pushnil(L);
+    return 1;
+  }
+
+  // First, serve any data already in the buffer from header overshoot
+  if (r->buf_pos < r->buf.n) {
+    size_t avail = r->buf.n - r->buf_pos;
+    if (r->body_state == kHttpClientStateBodyChunked) {
+      // Run unchunker on buffered data
+      // Reset i/j for fresh buffer (state machine state in t/m persists)
+      r->u.i = 0;
+      r->u.j = 0;
+      size_t paylen = 0;
+      rc = Unchunk(&r->u, r->buf.p + r->buf_pos, avail, &paylen);
+      if (rc == -1) {
+        lua_pushnil(L);
+        lua_pushliteral(L, "unchunk error");
+        return 2;
+      }
+      if (paylen > 0) {
+        lua_pushlstring(L, r->buf.p + r->buf_pos, paylen);
+        r->bytes_read += paylen;
+        if (rc) {
+          // Unchunk complete - all data received
+          FetchReaderClose(r);
+        }
+        // Mark buffer as consumed
+        r->buf_pos = r->buf.n;
+        return 1;
+      }
+      // Need more data - fall through to socket read
+      r->buf_pos = r->buf.n;
+    } else {
+      // Non-chunked: return buffered data directly
+      if (r->body_state == kHttpClientStateBodyLengthed) {
+        size_t remaining = r->content_length - r->bytes_read;
+        if (avail > remaining) avail = remaining;
+      }
+      lua_pushlstring(L, r->buf.p + r->buf_pos, avail);
+      r->buf_pos += avail;
+      r->bytes_read += avail;
+      return 1;
+    }
+  }
+
+  // Read from socket
+  char readbuf[16384];
+#ifndef UNSECURE
+  if (r->usingssl) {
+    rc = mbedtls_ssl_read(&r->sslctx, (unsigned char *)readbuf,
+                          sizeof(readbuf));
+    if (rc == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY || rc == 0) {
+      // EOF
+      if (r->body_state == kHttpClientStateBody) {
+        lua_pushnil(L);
+        return 1;
+      }
+      lua_pushnil(L);
+      lua_pushliteral(L, "unexpected EOF");
+      return 2;
+    }
+    if (rc < 0) {
+      char errbuf[300];
+      mbedtls_strerror(rc, errbuf, sizeof(errbuf));
+      lua_pushnil(L);
+      lua_pushstring(L, errbuf);
+      return 2;
+    }
+  } else
+#endif
+  {
+    rc = READ(r->sock, readbuf, sizeof(readbuf));
+    if (rc == 0) {
+      // EOF
+      if (r->body_state == kHttpClientStateBody) {
+        lua_pushnil(L);
+        return 1;
+      }
+      lua_pushnil(L);
+      lua_pushliteral(L, "unexpected EOF");
+      return 2;
+    }
+    if (rc == -1) {
+      lua_pushnil(L);
+      lua_pushstring(L, strerror(errno));
+      return 2;
+    }
+  }
+
+  // Process the data we read
+  if (r->body_state == kHttpClientStateBodyChunked) {
+    // Reset i/j for fresh buffer (state machine state in t/m persists)
+    r->u.i = 0;
+    r->u.j = 0;
+    size_t paylen = 0;
+    int uc = Unchunk(&r->u, readbuf, rc, &paylen);
+    if (uc == -1) {
+      lua_pushnil(L);
+      lua_pushliteral(L, "unchunk error");
+      return 2;
+    }
+    if (paylen > 0) {
+      lua_pushlstring(L, readbuf, paylen);
+      r->bytes_read += paylen;
+      if (uc) {
+        // Final chunk received
+        FetchReaderClose(r);
+      }
+      return 1;
+    }
+    // Got chunk framing but no data yet, try again
+    lua_pushliteral(L, "");
+    return 1;
+  }
+
+  // Non-chunked body
+  size_t len = rc;
+  if (r->body_state == kHttpClientStateBodyLengthed) {
+    size_t remaining = r->content_length - r->bytes_read;
+    if (len > remaining) len = remaining;
+  }
+  lua_pushlstring(L, readbuf, len);
+  r->bytes_read += len;
+  if (r->body_state == kHttpClientStateBodyLengthed &&
+      r->bytes_read >= r->content_length) {
+    FetchReaderClose(r);
+  }
+  return 1;
+}
+
+// reader:close()
+static int LuaFetchReaderCloseMethod(lua_State *L) {
+  FetchReader *r = CheckFetchReader(L);
+  FetchReaderClose(r);
+  return 0;
+}
+
+// __gc metamethod
+static int LuaFetchReaderGc(lua_State *L) {
+  FetchReader *r = (FetchReader *)luaL_checkudata(L, 1, FETCH_READER_MT);
+  FetchReaderClose(r);
+  return 0;
+}
+
+// __tostring metamethod
+static int LuaFetchReaderTostring(lua_State *L) {
+  FetchReader *r = CheckFetchReader(L);
+  if (r->closed) {
+    lua_pushliteral(L, "FetchReader(closed)");
+  } else {
+    lua_pushfstring(L, "FetchReader(fd=%d%s)", r->sock,
+                    r->usingssl ? ", ssl" : "");
+  }
+  return 1;
+}
+
+static const luaL_Reg kFetchReaderMethods[] = {
+    {"read", LuaFetchReaderRead},
+    {"close", LuaFetchReaderCloseMethod},
+    {0},
+};
+
+void LuaInitFetchReader(lua_State *L) {
+  luaL_newmetatable(L, FETCH_READER_MT);
+  lua_pushvalue(L, -1);
+  lua_setfield(L, -2, "__index");
+  lua_pushcfunction(L, LuaFetchReaderGc);
+  lua_setfield(L, -2, "__gc");
+  lua_pushcfunction(L, LuaFetchReaderTostring);
+  lua_setfield(L, -2, "__tostring");
+  luaL_setfuncs(L, kFetchReaderMethods, 0);
+  lua_pop(L, 1);
+}
+
+// FetchStream(url, opts) -> status, headers, reader
+// Shares all setup with Fetch but returns a reader instead of buffering body.
+int LuaFetchStream(lua_State *L) {
+#define ssl nope
+  ssize_t rc;
+  bool usingssl;
+  uint32_t ip;
+  struct Url url;
+  struct Url proxyurl;
+  int t, ret, sock = -1, hdridx;
+  const char *host, *port;
+  const char *proxyhost = 0, *proxyport = 0;
+  const char *proxyarg = 0;
+  size_t proxyarglen = 0;
+  char *proxyauthhdr = 0;
+  char *request;
+  struct TlsBio *bio;
+  mbedtls_ssl_context sslctx;
+  bool sslctx_initialized = false;
+  struct addrinfo *addr;
+  struct Buffer inbuf;
+  struct HttpMessage msg;
+  const char *urlarg, *body, *method;
+  char *conlenhdr = "";
+  char *headers = 0;
+  const char *hosthdr = 0;
+  const char *agenthdr = brand;
+  const char *key, *val, *hdr;
+  size_t keylen, vallen;
+  size_t urlarglen, requestlen, paylen, bodylen;
+  size_t i, g, hdrsize;
+  char canmethod[9] = {0};
+  uint64_t imethod;
+  int numredirects = 0, maxredirects = 5;
+  bool followredirect = true;
+#ifndef UNSECURE
+  bool resettls = true;
+#endif
+  size_t maxresponse = 100 * 1024 * 1024;
+  struct addrinfo hints = {.ai_family = AF_INET,
+                           .ai_socktype = SOCK_STREAM,
+                           .ai_protocol = IPPROTO_TCP,
+                           .ai_flags = AI_NUMERICSERV};
+
+  (void)ret;
+  (void)usingssl;
+
+  // ---- Parse arguments (same as LuaFetch) ----
+  urlarg = luaL_checklstring(L, 1, &urlarglen);
+  if (lua_istable(L, 2)) {
+    lua_settop(L, 2);
+    lua_getfield(L, 2, "body");
+    body = luaL_optlstring(L, -1, "", &bodylen);
+    lua_getfield(L, 2, "method");
+    method = luaL_optstring(L, -1, "GET");
+    if ((imethod = ParseHttpMethod(method, -1))) {
+      WRITE64LE(canmethod, imethod);
+      method = canmethod;
+    } else {
+      return LuaNilError(L, "bad method");
+    }
+    lua_getfield(L, 2, "followredirect");
+    if (lua_isboolean(L, -1))
+      followredirect = lua_toboolean(L, -1);
+    lua_getfield(L, 2, "maxredirects");
+    maxredirects = luaL_optinteger(L, -1, maxredirects);
+    lua_getfield(L, 2, "numredirects");
+    numredirects = luaL_optinteger(L, -1, numredirects);
+    lua_getfield(L, 2, "maxresponse");
+    if (lua_isinteger(L, -1))
+      maxresponse = lua_tointeger(L, -1);
+#ifndef UNSECURE
+    lua_getfield(L, 2, "resettls");
+    if (lua_isboolean(L, -1))
+      resettls = lua_toboolean(L, -1);
+#endif
+    // Streaming always disables keepalive
+    lua_getfield(L, 2, "headers");
+    if (!lua_isnil(L, -1)) {
+      if (!lua_istable(L, -1))
+        return luaL_argerror(L, 2, "invalid headers value; table expected");
+      lua_pushnil(L);
+      while (lua_next(L, -2)) {
+        if (lua_type(L, -2) == LUA_TSTRING) {
+          key = lua_tolstring(L, -2, &keylen);
+          if (!IsValidHttpToken(key, keylen))
+            return LuaNilError(L, "invalid header name: %s", key);
+          val = lua_tolstring(L, -1, &vallen);
+          if (!(hdr = gc(EncodeHttpHeaderValue(val, vallen, 0))))
+            return LuaNilError(L, "invalid header %s value encoding", key);
+          if ((hdridx = GetHttpHeader(key, keylen)) == -1 ||
+              hdridx != kHttpContentLength) {
+            if (hdridx == kHttpUserAgent) {
+              agenthdr = hdr;
+            } else if (hdridx == kHttpHost) {
+              hosthdr = hdr;
+            } else if (hdridx == kHttpConnection) {
+              // Streaming always uses Connection: close; ignore user value
+            } else {
+              appendd(&headers, key, keylen);
+              appendw(&headers, READ16LE(": "));
+              appends(&headers, hdr);
+              appendw(&headers, READ16LE("\r\n"));
+            }
+          }
+        }
+        lua_pop(L, 1);
+      }
+    }
+    if (headers)
+      gc(headers);
+    lua_getfield(L, 2, "proxy");
+    if (!lua_isnil(L, -1)) {
+      if (!lua_isstring(L, -1))
+        return LuaNilError(L, "bad proxy; string expected");
+      proxyarg = lua_tolstring(L, -1, &proxyarglen);
+    }
+    lua_settop(L, 2);
+  } else if (lua_isnoneornil(L, 2)) {
+    body = "";
+    bodylen = 0;
+    method = "GET";
+  } else {
+    body = luaL_checklstring(L, 2, &bodylen);
+    method = "POST";
+  }
+  imethod = ParseHttpMethod(method, -1);
+  if (bodylen > 0 ||
+      !(imethod == kHttpGet || imethod == kHttpHead || imethod == kHttpTrace ||
+        imethod == kHttpDelete || imethod == kHttpConnect)) {
+    conlenhdr = gc(xasprintf("Content-Length: %zu\r\n", bodylen));
+  }
+
+  // ---- Parse URL ----
+  gc(ParseUrl(urlarg, urlarglen, &url, true));
+  gc(url.params.p);
+
+  usingssl = false;
+  if (url.scheme.n) {
+#ifndef UNSECURE
+    if (!unsecure && url.scheme.n == 5 &&
+        !memcasecmp(url.scheme.p, "https", 5)) {
+      usingssl = true;
+    } else
+#endif
+        if (!(url.scheme.n == 4 && !memcasecmp(url.scheme.p, "http", 4))) {
+      return LuaNilError(L, "bad scheme");
+    }
+  }
+
+#ifndef UNSECURE
+  if (usingssl && resettls)
+    LuaResetFetchTlsState();
+  if (usingssl && !sslinitialized)
+    TlsInit();
+#endif
+
+  // ---- Parse proxy ----
+  if (!proxyarg) {
+    proxyarg = getenv("http_proxy");
+    if (!proxyarg)
+      proxyarg = getenv("HTTP_PROXY");
+    if (proxyarg)
+      proxyarglen = strlen(proxyarg);
+  }
+  if (proxyarg && proxyarglen) {
+    gc(ParseUrl(proxyarg, proxyarglen, &proxyurl, true));
+    gc(proxyurl.params.p);
+    if (!(proxyurl.scheme.n == 4 &&
+          !memcasecmp(proxyurl.scheme.p, "http", 4))) {
+      return LuaNilError(L, "bad proxy scheme; only http:// proxies supported");
+    }
+    if (!proxyurl.host.n)
+      return LuaNilError(L, "bad proxy; missing host");
+    proxyhost = gc(strndup(proxyurl.host.p, proxyurl.host.n));
+    proxyport = proxyurl.port.n
+                    ? gc(strndup(proxyurl.port.p, proxyurl.port.n))
+                    : "80";
+    if (!IsAcceptableHost(proxyhost, -1))
+      return LuaNilError(L, "bad proxy; invalid host");
+    if (!IsAcceptablePort(proxyport, -1))
+      return LuaNilError(L, "bad proxy; invalid port");
+    if (proxyurl.user.n) {
+      char *creds = gc(xasprintf("%.*s:%.*s",
+                                 (int)proxyurl.user.n, proxyurl.user.p,
+                                 (int)proxyurl.pass.n, proxyurl.pass.p));
+      char *b64 = gc(EncodeBase64(creds, strlen(creds), 0));
+      if (b64)
+        proxyauthhdr = gc(xasprintf("Proxy-Authorization: Basic %s\r\n", b64));
+    }
+  }
+
+  if (url.host.n) {
+    host = gc(strndup(url.host.p, url.host.n));
+    if (url.port.n) {
+      port = gc(strndup(url.port.p, url.port.n));
+#ifndef UNSECURE
+    } else if (usingssl) {
+      port = "443";
+#endif
+    } else {
+      port = "80";
+    }
+  } else if ((ip = ParseIp(urlarg, -1)) != -1) {
+    host = urlarg;
+    port = "80";
+  } else {
+    return LuaNilError(L, "invalid host");
+  }
+  if (!IsAcceptableHost(host, -1))
+    return LuaNilError(L, "invalid host");
+  if (!IsAcceptablePort(port, -1))
+    return LuaNilError(L, "invalid port");
+  if (!hosthdr)
+    hosthdr = gc(xasprintf("%s:%s", host, port));
+
+  url.fragment.p = 0, url.fragment.n = 0;
+  url.user.p = 0, url.user.n = 0;
+  url.pass.p = 0, url.pass.n = 0;
+  if (!proxyhost || usingssl) {
+    url.scheme.p = 0, url.scheme.n = 0;
+    url.host.p = 0, url.host.n = 0;
+    url.port.p = 0, url.port.n = 0;
+  }
+  if (!url.path.n || url.path.p[0] != '/') {
+    void *p = gc(xmalloc(1 + url.path.n));
+    mempcpy(mempcpy(p, "/", 1), url.path.p, url.path.n);
+    url.path.p = p;
+    ++url.path.n;
+  }
+
+  // ---- Build HTTP request ----
+  request = 0;
+  appendf(&request,
+          "%s %s HTTP/1.1\r\n"
+          "Host: %s\r\n"
+          "Connection: close\r\n"
+          "User-Agent: %s\r\n"
+          "%s%s%s"
+          "\r\n",
+          method, gc(EncodeUrl(&url, 0)), hosthdr,
+          agenthdr, conlenhdr,
+          (proxyhost && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
+          headers ? headers : "");
+  appendd(&request, body, bodylen);
+  requestlen = appendz(request).i;
+  gc(request);
+
+  // ---- Connect ----
+  {
+    const char *connecthost = proxyhost ? proxyhost : host;
+    const char *connectport = proxyhost ? proxyport : port;
+    if ((rc = getaddrinfo(connecthost, connectport, &hints, &addr)) != 0)
+      return LuaNilError(L, "getaddrinfo(%s:%s) error: EAI_%s %s", connecthost,
+                         connectport, gai_strerror(rc), strerror(errno));
+    ip = ntohl(((struct sockaddr_in *)addr->ai_addr)->sin_addr.s_addr);
+    if (!proxyhost && (IsLoopbackIp(ip) || IsPrivateIp(ip))) {
+      freeaddrinfo(addr);
+      return LuaNilError(L, "request to private network blocked (SSRF protection)");
+    }
+    if ((sock = GoodSocket(addr->ai_family, addr->ai_socktype,
+                           addr->ai_protocol, false, &timeout)) == -1) {
+      freeaddrinfo(addr);
+      return LuaNilError(L, "socket error: %s", strerror(errno));
+    }
+    rc = connect(sock, addr->ai_addr, addr->ai_addrlen);
+    freeaddrinfo(addr);
+    if (rc == -1) {
+      close(sock);
+      return LuaNilError(L, "connect error: %s", strerror(errno));
+    }
+  }
+
+  (void)bio;
+#ifndef UNSECURE
+  // ---- HTTPS proxy CONNECT tunnel ----
+  if (usingssl && proxyhost) {
+    char *connectreq = 0;
+    char connectbuf[1024];
+    ssize_t connectrc;
+    appendf(&connectreq,
+            "CONNECT %s:%s HTTP/1.1\r\n"
+            "Host: %s:%s\r\n"
+            "User-Agent: %s\r\n"
+            "Proxy-Connection: keep-alive\r\n"
+            "%s"
+            "\r\n",
+            host, port, host, port, agenthdr,
+            proxyauthhdr ? proxyauthhdr : "");
+    size_t connectreqlen = appendz(connectreq).i;
+    gc(connectreq);
+    for (i = 0; i < connectreqlen; i += connectrc) {
+      if ((connectrc = WRITE(sock, connectreq + i, connectreqlen - i)) <= 0) {
+        close(sock);
+        return LuaNilError(L, "proxy CONNECT write error: %s", strerror(errno));
+      }
+    }
+    if ((connectrc = READ(sock, connectbuf, sizeof(connectbuf) - 1)) <= 0) {
+      close(sock);
+      return LuaNilError(L, "proxy CONNECT read error: %s", strerror(errno));
+    }
+    connectbuf[connectrc] = '\0';
+    if (!strstr(connectbuf, " 200 ")) {
+      close(sock);
+      return LuaNilError(L, "proxy CONNECT failed: %.64s", connectbuf);
+    }
+  }
+
+  // ---- TLS handshake ----
+  bio = NULL;
+  if (usingssl) {
+    mbedtls_ssl_init(&sslctx);
+    sslctx_initialized = true;
+    if ((ret = mbedtls_ssl_setup(&sslctx, &confcli)) != 0) {
+      mbedtls_ssl_free(&sslctx);
+      close(sock);
+      return LuaNilTlsError(L, "ssl_setup", ret);
+    }
+    if (!evadedragnetsurveillance)
+      mbedtls_ssl_set_hostname(&sslctx, host);
+    bio = malloc(sizeof(struct TlsBio));
+    if (!bio) {
+      mbedtls_ssl_free(&sslctx);
+      close(sock);
+      return LuaNilError(L, "out of memory");
+    }
+    bio->fd = sock;
+    bio->a = 0;
+    bio->b = 0;
+    bio->c = -1;
+    mbedtls_ssl_set_bio(&sslctx, bio, TlsSend, 0, TlsRecvImpl);
+    while ((ret = mbedtls_ssl_handshake(&sslctx))) {
+      switch (ret) {
+        case MBEDTLS_ERR_SSL_WANT_READ:
+          break;
+        case MBEDTLS_ERR_X509_CERT_VERIFY_FAILED:
+          goto StreamVerifyFailed;
+        default:
+          free(bio);
+          mbedtls_ssl_free(&sslctx);
+          close(sock);
+          return LuaNilTlsError(L, "handshake", ret);
+      }
+    }
+    LockInc(&shared->c.sslhandshakes);
+  }
+#endif
+
+  // ---- Send request ----
+  for (i = 0; i < requestlen; i += rc) {
+#ifndef UNSECURE
+    if (usingssl) {
+      rc = mbedtls_ssl_write(&sslctx, (unsigned char *)request + i,
+                             requestlen - i);
+      if (rc <= 0) {
+        if (rc == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED)
+          goto StreamVerifyFailed;
+        free(bio);
+        mbedtls_ssl_free(&sslctx);
+        close(sock);
+        return LuaNilTlsError(L, "write", rc);
+      }
+    } else
+#endif
+        if ((rc = WRITE(sock, request + i, requestlen - i)) <= 0) {
+      close(sock);
+      return LuaNilError(L, "write error: %s", strerror(errno));
+    }
+  }
+
+  // ---- Read headers only ----
+  bzero(&inbuf, sizeof(inbuf));
+  InitHttpMessage(&msg, kHttpResponse);
+  for (hdrsize = paylen = t = 0;;) {
+    if (inbuf.n == inbuf.c) {
+      char *newp;
+      inbuf.c += 1000;
+      inbuf.c += inbuf.c >> 1;
+      if (inbuf.c > maxresponse) {
+        goto StreamCleanupError;
+      }
+      if (!(newp = realloc(inbuf.p, inbuf.c))) {
+        goto StreamCleanupError;
+      }
+      inbuf.p = newp;
+    }
+#ifndef UNSECURE
+    if (usingssl) {
+      if ((rc = mbedtls_ssl_read(&sslctx, (unsigned char *)inbuf.p + inbuf.n,
+                                 inbuf.c - inbuf.n)) < 0) {
+        if (rc == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+          rc = 0;
+        } else {
+          DestroyHttpMessage(&msg);
+          free(inbuf.p);
+          free(bio);
+          mbedtls_ssl_free(&sslctx);
+          close(sock);
+          return LuaNilTlsError(L, "read", rc);
+        }
+      }
+    } else
+#endif
+        if ((rc = READ(sock, inbuf.p + inbuf.n, inbuf.c - inbuf.n)) == -1) {
+      DestroyHttpMessage(&msg);
+      free(inbuf.p);
+#ifndef UNSECURE
+      if (sslctx_initialized) { free(bio); mbedtls_ssl_free(&sslctx); }
+#endif
+      close(sock);
+      return LuaNilError(L, "read error: %s", strerror(errno));
+    }
+    g = rc;
+    inbuf.n += g;
+
+    if (!t) {
+      // Still parsing headers
+      if (!g) {
+        goto StreamCleanupError;
+      }
+      rc = ParseHttpMessage(&msg, inbuf.p, inbuf.n, SHRT_MAX);
+      if (rc == -1) {
+        goto StreamCleanupError;
+      }
+      if (rc) {
+        hdrsize = rc;
+        // Handle 1xx continue
+        if (100 <= msg.status && msg.status <= 199) {
+          if ((FetchHasHeader(kHttpContentLength) &&
+               !FetchHeaderEqualCase(kHttpContentLength, "0")) ||
+              (FetchHasHeader(kHttpTransferEncoding) &&
+               !FetchHeaderEqualCase(kHttpTransferEncoding, "identity"))) {
+            goto StreamCleanupError;
+          }
+          DestroyHttpMessage(&msg);
+          InitHttpMessage(&msg, kHttpResponse);
+          memmove(inbuf.p, inbuf.p + hdrsize, inbuf.n - hdrsize);
+          inbuf.n -= hdrsize;
+          continue;
+        }
+        // Handle no-body responses
+        if (msg.status == 204 || msg.status == 304) {
+          // Return status, headers, and a closed reader (no body)
+          goto StreamFinishNoBody;
+        }
+        // Handle redirects before streaming
+        if (followredirect && FetchHasHeader(kHttpLocation) &&
+            (msg.status == 301 || msg.status == 308 ||
+             msg.status == 302 || msg.status == 307 ||
+             msg.status == 303) &&
+            numredirects < maxredirects) {
+          // Clean up and follow redirect
+          if (msg.status == 303) {
+            body = "";
+            bodylen = 0;
+            method = "GET";
+          }
+          if (!lua_istable(L, 2)) {
+            lua_settop(L, 1);
+            lua_createtable(L, 0, 3);
+          }
+          lua_pushlstring(L, body, bodylen);
+          lua_setfield(L, -2, "body");
+          lua_pushstring(L, method);
+          lua_setfield(L, -2, "method");
+          lua_pushinteger(L, numredirects + 1);
+          lua_setfield(L, -2, "numredirects");
+          // Parse redirect URL
+          gc(ParseUrl(FetchHeaderData(kHttpLocation),
+                      FetchHeaderLength(kHttpLocation), &url, true));
+          free(url.params.p);
+#ifndef UNSECURE
+          if (usingssl && url.scheme.n == 4 &&
+              !memcasecmp(url.scheme.p, "http", 4)) {
+            DestroyHttpMessage(&msg);
+            free(inbuf.p);
+            if (sslctx_initialized) { free(bio); mbedtls_ssl_free(&sslctx); }
+            close(sock);
+            return LuaNilError(L, "refusing HTTPS to HTTP redirect downgrade");
+          }
+#endif
+          // Strip auth headers on cross-origin redirect
+          if (url.host.n && url.scheme.n && lua_istable(L, 2)) {
+            lua_getfield(L, 2, "headers");
+            if (lua_istable(L, -1)) {
+              lua_pushnil(L); lua_setfield(L, -2, "Authorization");
+              lua_pushnil(L); lua_setfield(L, -2, "authorization");
+              lua_pushnil(L); lua_setfield(L, -2, "Cookie");
+              lua_pushnil(L); lua_setfield(L, -2, "cookie");
+            }
+            lua_pop(L, 1);
+          }
+          if (url.host.n && url.scheme.n) {
+            lua_pushlstring(L, FetchHeaderData(kHttpLocation),
+                            FetchHeaderLength(kHttpLocation));
+          } else {
+            gc(ParseUrl(urlarg, urlarglen, &url, true));
+            free(url.params.p);
+            url.fragment.p = 0, url.fragment.n = 0;
+            url.user.p = 0, url.user.n = 0;
+            url.pass.p = 0, url.pass.n = 0;
+            if (FetchHeaderLength(kHttpLocation) > 0 &&
+                FetchHeaderData(kHttpLocation)[0] == '/') {
+              url.path.n = 0;
+            } else {
+              while (url.path.n > 0 && url.path.p[url.path.n - 1] != '/')
+                --url.path.n;
+            }
+            url.path.p = gc(xasprintf("%.*s%.*s", url.path.n, url.path.p,
+                                      FetchHeaderLength(kHttpLocation),
+                                      FetchHeaderData(kHttpLocation)));
+            url.path.n = strlen(url.path.p);
+            lua_pushstring(L, gc(EncodeUrl(&url, 0)));
+          }
+          lua_replace(L, -3);
+          DestroyHttpMessage(&msg);
+          free(inbuf.p);
+#ifndef UNSECURE
+          if (sslctx_initialized) { free(bio); mbedtls_ssl_free(&sslctx); }
+#endif
+          close(sock);
+          return LuaFetchStream(L);
+        }
+        // Determine body transfer mode
+        if (FetchHasHeader(kHttpTransferEncoding) &&
+            !FetchHeaderEqualCase(kHttpTransferEncoding, "identity")) {
+          if (FetchHeaderEqualCase(kHttpTransferEncoding, "chunked")) {
+            t = kHttpClientStateBodyChunked;
+          } else {
+            goto StreamCleanupError;
+          }
+        } else if (FetchHasHeader(kHttpContentLength)) {
+          rc = ParseContentLength(FetchHeaderData(kHttpContentLength),
+                                  FetchHeaderLength(kHttpContentLength));
+          if (rc == -1)
+            goto StreamCleanupError;
+          paylen = rc;
+          t = kHttpClientStateBodyLengthed;
+        } else {
+          t = kHttpClientStateBody;
+        }
+        // Headers parsed - create reader and return
+        goto StreamCreateReader;
+      }
+    } else {
+      // We shouldn't reach here - headers loop should break via goto
+      goto StreamCleanupError;
+    }
+  }
+
+StreamCreateReader: {
+    // Push status and headers BEFORE we modify the buffer
+    // (header offsets in msg point into inbuf.p)
+    lua_pushinteger(L, msg.status);
+    LuaPushHeaders(L, &msg, inbuf.p);
+    DestroyHttpMessage(&msg);
+
+    FetchReader *reader = lua_newuserdata(L, sizeof(FetchReader));
+    memset(reader, 0, sizeof(FetchReader));
+    luaL_setmetatable(L, FETCH_READER_MT);
+
+    reader->sock = sock;
+    reader->usingssl = usingssl;
+    reader->body_state = t;
+    reader->content_length = paylen;
+    reader->bytes_read = 0;
+
+    // Transfer buffer ownership (may contain body data after headers)
+    reader->buf = inbuf;
+    reader->buf_pos = hdrsize;  // body starts after headers
+
+    // Initialize unchunker if chunked
+    if (t == kHttpClientStateBodyChunked) {
+      bzero(&reader->u, sizeof(reader->u));
+      // Shift body data to start of buffer for unchunker
+      if (inbuf.n > hdrsize) {
+        size_t body_avail = inbuf.n - hdrsize;
+        memmove(inbuf.p, inbuf.p + hdrsize, body_avail);
+        reader->buf.n = body_avail;
+        reader->buf_pos = 0;
+      } else {
+        reader->buf.n = 0;
+        reader->buf_pos = 0;
+      }
+    }
+
+#ifndef UNSECURE
+    if (sslctx_initialized) {
+      memcpy(&reader->sslctx, &sslctx, sizeof(sslctx));
+      reader->bio = bio;
+      reader->sslctx_initialized = true;
+      // Rebind bio to copied context
+      mbedtls_ssl_set_bio(&reader->sslctx, reader->bio, TlsSend, 0,
+                          TlsRecvImpl);
+    }
+#endif
+
+    // Stack: ..., status, headers, reader
+    // Don't free inbuf.p - reader owns it now
+    // Don't free bio - reader owns it now
+    // Don't close sock - reader owns it now
+    // Don't free sslctx - reader owns it now
+    return 3;
+  }
+
+StreamFinishNoBody: {
+    // Push status and headers before cleanup
+    lua_pushinteger(L, msg.status);
+    LuaPushHeaders(L, &msg, inbuf.p);
+    DestroyHttpMessage(&msg);
+    free(inbuf.p);
+#ifndef UNSECURE
+    if (sslctx_initialized) {
+      free(bio);
+      mbedtls_ssl_free(&sslctx);
+    }
+#endif
+    close(sock);
+
+    // Create a closed reader (no body)
+    FetchReader *reader = lua_newuserdata(L, sizeof(FetchReader));
+    memset(reader, 0, sizeof(FetchReader));
+    luaL_setmetatable(L, FETCH_READER_MT);
+    reader->sock = -1;
+    reader->closed = true;
+
+    // Stack: ..., status, headers, reader
+    return 3;
+  }
+
+StreamCleanupError:
+  DestroyHttpMessage(&msg);
+  free(inbuf.p);
+#ifndef UNSECURE
+  if (sslctx_initialized) {
+    free(bio);
+    mbedtls_ssl_free(&sslctx);
+  }
+#endif
+  close(sock);
+  return LuaNilError(L, "transport error");
+
+#ifndef UNSECURE
+StreamVerifyFailed:
+  LockInc(&shared->c.sslverifyfailed);
+  {
+    uint32_t verify_result = sslctx.session_negotiate->verify_result;
+    free(bio);
+    mbedtls_ssl_free(&sslctx);
+    close(sock);
+    return LuaNilTlsError(L, gc(DescribeSslVerifyFailure(verify_result)), ret);
+  }
+#endif
+#undef ssl
+}
+
 void LuaInitFetch(void) {
   // SSL mutex is now statically initialized, nothing else needed here
   // TlsInit() will be called on first HTTPS request

--- a/tool/net/lfetch.h
+++ b/tool/net/lfetch.h
@@ -4,7 +4,9 @@
 COSMOPOLITAN_C_START_
 
 int LuaFetch(lua_State *);
+int LuaFetchStream(lua_State *);
 void LuaInitFetch(void);
+void LuaInitFetchReader(lua_State *);
 
 COSMOPOLITAN_C_END_
 #endif /* COSMOPOLITAN_TOOL_NET_LFETCH_H_ */


### PR DESCRIPTION
Add `cosmo.FetchStream(url, opts)` that returns `(status, headers, reader)` where reader is a userdata object with `:read()` and `:close()` methods. Unlike `Fetch` which buffers the entire response, `FetchStream` returns headers immediately and yields body chunks incrementally via `reader:read()`.

This enables SSE (Server-Sent Events) streaming from APIs like Claude's, where buffering the full response causes unacceptable latency - users see nothing for 10+ seconds then all text appears at once.

## API

```lua
local status, headers, reader = cosmo.FetchStream(url, opts)
while true do
    local chunk, err = reader:read()
    if not chunk then
        if err then error(err) end
        break  -- EOF
    end
    process(chunk)
end
reader:close()
```

## Features

- Supports Content-Length, chunked, and close-delimited bodies
- Has `__gc` metamethod for safe cleanup if `reader:close()` is forgotten
- Handles HTTPS via mbedtls with proper TLS context ownership transfer
- Supports redirects (resolved before streaming begins)
- Always uses `Connection: close` (no keepalive for streaming)

## Changes

- `tool/net/lfetch.c`: Add `LuaFetchStream` and `FetchReader` userdata
- `tool/net/lfetch.h`: Export new functions
- `tool/lua/lcosmo.c`: Register `FetchStream` in cosmo module
- `test/tool/net/lfetchstream_test.lua`: 7 tests covering all body transfer modes
- `test/tool/net/BUILD.mk`: Add pledge rule for test

https://github.com/whilp/ah/blob/abb7fad571e6fda63b739a680375d8089344f71b/STREAMING.md