### PR TITLE
fetch: add unix:// domain socket proxy support

### DIFF
--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -188,6 +188,10 @@ o/$(MODE)/tool/lua/test_isatty.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_isat
 	$< tool/lua/test_isatty.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_fetch_unix_proxy.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_fetch_unix_proxy.lua
+	$< tool/lua/test_fetch_unix_proxy.lua
+	@touch $@
+
 TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_cosmo.ok				\
 	o/$(MODE)/tool/lua/cosmo/help/test.ok				\
@@ -207,7 +211,8 @@ TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_embed.ok				\
 	o/$(MODE)/tool/lua/test_embed_integration.ok			\
 	o/$(MODE)/tool/lua/test_unix_proc.ok				\
-	o/$(MODE)/tool/lua/test_isatty.ok
+	o/$(MODE)/tool/lua/test_isatty.ok				\
+	o/$(MODE)/tool/lua/test_fetch_unix_proxy.ok
 
 .PHONY: o/$(MODE)/tool/lua
 o/$(MODE)/tool/lua:							\

--- a/tool/lua/test_fetch_unix_proxy.lua
+++ b/tool/lua/test_fetch_unix_proxy.lua
@@ -59,7 +59,18 @@ local function test_socket_not_found()
 end
 
 --------------------------------------------------------------------------------
--- Test 4: FetchStream error - missing socket path
+-- Test 4: Error - path traversal with ".." segments
+--------------------------------------------------------------------------------
+local function test_path_traversal()
+  local status, headers, body = cosmo.Fetch("http://example.com", {
+    proxy = "unix:///tmp/../etc/shadow.sock"
+  })
+  check("path traversal should fail", status == nil)
+  check("error mentions path segments", headers:find("%.") or headers:find("segment"))
+end
+
+--------------------------------------------------------------------------------
+-- Test 5: FetchStream error - missing socket path
 --------------------------------------------------------------------------------
 local function test_stream_missing_path()
   local status, err = cosmo.FetchStream("http://example.com", {
@@ -94,6 +105,17 @@ local function test_stream_socket_not_found()
 end
 
 --------------------------------------------------------------------------------
+-- Test 7: FetchStream error - path traversal
+--------------------------------------------------------------------------------
+local function test_stream_path_traversal()
+  local status, err = cosmo.FetchStream("http://example.com", {
+    proxy = "unix:///tmp/../etc/shadow.sock"
+  })
+  check("FetchStream path traversal should fail", status == nil)
+  check("error mentions path segments", err:find("%.") or err:find("segment"))
+end
+
+--------------------------------------------------------------------------------
 -- Run all tests
 --------------------------------------------------------------------------------
 print("Running unix socket proxy tests...")
@@ -107,6 +129,9 @@ print("  [pass] path too long error (security fix)")
 test_socket_not_found()
 print("  [pass] socket not found error")
 
+test_path_traversal()
+print("  [pass] path traversal rejected")
+
 test_stream_missing_path()
 print("  [pass] FetchStream missing path error")
 
@@ -115,5 +140,8 @@ print("  [pass] FetchStream path too long error (security fix)")
 
 test_stream_socket_not_found()
 print("  [pass] FetchStream socket not found error")
+
+test_stream_path_traversal()
+print("  [pass] FetchStream path traversal rejected")
 
 print("all unix socket proxy tests passed")

--- a/tool/lua/test_fetch_unix_proxy.lua
+++ b/tool/lua/test_fetch_unix_proxy.lua
@@ -1,0 +1,119 @@
+-- Test for unix:// socket proxy support in Fetch and FetchStream
+-- Tests error handling (path validation) which is the core security fix
+-- Functional proxy tests require forking and may not work in all CI environments
+
+local cosmo = require("cosmo")
+local unix = require("cosmo.unix")
+
+local tmpdir = os.getenv("TMPDIR") or "/tmp"
+local sockpath = tmpdir .. "/test-proxy-" .. unix.getpid() .. ".sock"
+
+-- Helper for assertions
+local function check(desc, cond)
+  if not cond then
+    error("FAILED: " .. desc)
+  end
+end
+
+-- Cleanup function
+local function cleanup()
+  pcall(function() unix.unlink(sockpath) end)
+end
+
+--------------------------------------------------------------------------------
+-- Test 1: Error - missing socket path
+--------------------------------------------------------------------------------
+local function test_missing_path()
+  local status, headers, body = cosmo.Fetch("http://example.com", {
+    proxy = "unix://"
+  })
+  check("missing path should fail", status == nil)
+  check("error mentions socket path", headers:find("socket path"))
+end
+
+--------------------------------------------------------------------------------
+-- Test 2: Error - socket path too long (SECURITY FIX)
+-- This prevents silent truncation which could lead to connecting to
+-- unintended sockets
+--------------------------------------------------------------------------------
+local function test_path_too_long()
+  -- sun_path is 108 bytes on Linux
+  -- Use unix:/// (three slashes) so the long string is in path, not host
+  local long_path = "unix:///" .. string.rep("a", 200)
+  local status, headers, body = cosmo.Fetch("http://example.com", {
+    proxy = long_path
+  })
+  check("long path should fail", status == nil)
+  check("error mentions too long", headers:find("too long"))
+end
+
+--------------------------------------------------------------------------------
+-- Test 3: Error - socket doesn't exist
+--------------------------------------------------------------------------------
+local function test_socket_not_found()
+  local status, headers, body = cosmo.Fetch("http://example.com", {
+    proxy = "unix:///nonexistent/path/to/socket.sock"
+  })
+  check("nonexistent socket should fail", status == nil)
+  check("error mentions connect failure", headers:find("connect") or headers:find("failed"))
+end
+
+--------------------------------------------------------------------------------
+-- Test 4: FetchStream error - missing socket path
+--------------------------------------------------------------------------------
+local function test_stream_missing_path()
+  local status, err = cosmo.FetchStream("http://example.com", {
+    proxy = "unix://"
+  })
+  check("FetchStream missing path should fail", status == nil)
+  check("error mentions socket path", err:find("socket path"))
+end
+
+--------------------------------------------------------------------------------
+-- Test 5: FetchStream error - socket path too long (SECURITY FIX)
+--------------------------------------------------------------------------------
+local function test_stream_path_too_long()
+  -- Use unix:/// (three slashes) so the long string is in path, not host
+  local long_path = "unix:///" .. string.rep("a", 200)
+  local status, err = cosmo.FetchStream("http://example.com", {
+    proxy = long_path
+  })
+  check("FetchStream long path should fail", status == nil)
+  check("error mentions too long", err:find("too long"))
+end
+
+--------------------------------------------------------------------------------
+-- Test 6: FetchStream error - socket doesn't exist
+--------------------------------------------------------------------------------
+local function test_stream_socket_not_found()
+  local status, err = cosmo.FetchStream("http://example.com", {
+    proxy = "unix:///nonexistent/path/to/socket.sock"
+  })
+  check("FetchStream nonexistent socket should fail", status == nil)
+  check("error mentions connect failure", err:find("connect") or err:find("failed"))
+end
+
+--------------------------------------------------------------------------------
+-- Run all tests
+--------------------------------------------------------------------------------
+print("Running unix socket proxy tests...")
+
+test_missing_path()
+print("  [pass] missing path error")
+
+test_path_too_long()
+print("  [pass] path too long error (security fix)")
+
+test_socket_not_found()
+print("  [pass] socket not found error")
+
+test_stream_missing_path()
+print("  [pass] FetchStream missing path error")
+
+test_stream_path_too_long()
+print("  [pass] FetchStream path too long error (security fix)")
+
+test_stream_socket_not_found()
+print("  [pass] FetchStream socket not found error")
+
+print("all unix socket proxy tests passed")

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -240,6 +240,9 @@ int LuaFetch(lua_State *L) {
         return LuaNilError(L, "bad unix proxy; socket path too long (max %zu)",
                            sizeof(((struct sockaddr_un *)0)->sun_path) - 1);
       }
+      if (!IsReasonablePath(proxyurl.path.p, proxyurl.path.n)) {
+        return LuaNilError(L, "bad unix proxy; path contains . or .. segments");
+      }
       proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
       DEBUGF("(ftch) using unix proxy %s", proxysockpath);
       // Disable keepalive when using proxy for simplicity
@@ -359,7 +362,7 @@ int LuaFetch(lua_State *L) {
               ? "close"
               : (connhdr ? connhdr : "keep-alive"),
           agenthdr, conlenhdr,
-          ((proxyhost || proxyunix) && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
+          (proxyhost && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
           headers ? headers : "");
   appendd(&request, body, bodylen);
   requestlen = appendz(request).i;

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -35,6 +35,8 @@ int LuaFetch(lua_State *L) {
   const char *proxyarg = 0;
   size_t proxyarglen = 0;
   char *proxyauthhdr = 0;
+  bool proxyunix = false;
+  char *proxysockpath = NULL;
   char *request;
   struct TlsBio *bio;
   mbedtls_ssl_context sslctx;
@@ -226,40 +228,53 @@ int LuaFetch(lua_State *L) {
   if (proxyarg && proxyarglen) {
     gc(ParseUrl(proxyarg, proxyarglen, &proxyurl, true));
     gc(proxyurl.params.p);
-    // Proxy must use http:// scheme (not https, socks, etc.)
-    if (!(proxyurl.scheme.n == 4 &&
-          !memcasecmp(proxyurl.scheme.p, "http", 4))) {
-      return LuaNilError(L, "bad proxy scheme; only http:// proxies supported");
-    }
-    if (!proxyurl.host.n) {
-      return LuaNilError(L, "bad proxy; missing host");
-    }
-    proxyhost = gc(strndup(proxyurl.host.p, proxyurl.host.n));
-    if (proxyurl.port.n) {
-      proxyport = gc(strndup(proxyurl.port.p, proxyurl.port.n));
-    } else {
-      proxyport = "80";
-    }
-    if (!IsAcceptableHost(proxyhost, -1)) {
-      return LuaNilError(L, "bad proxy; invalid host");
-    }
-    if (!IsAcceptablePort(proxyport, -1)) {
-      return LuaNilError(L, "bad proxy; invalid port");
-    }
-    DEBUGF("(ftch) using proxy %s:%s", proxyhost, proxyport);
-    // Disable keepalive when using proxy for simplicity
-    keepalive = kaNONE;
-    // Build Proxy-Authorization header if credentials present
-    if (proxyurl.user.n) {
-      char *creds = gc(xasprintf("%.*s:%.*s",
-                                 (int)proxyurl.user.n, proxyurl.user.p,
-                                 (int)proxyurl.pass.n, proxyurl.pass.p));
-      size_t credslen = strlen(creds);
-      char *b64 = gc(EncodeBase64(creds, credslen, 0));
-      if (b64) {
-        proxyauthhdr = gc(xasprintf("Proxy-Authorization: Basic %s\r\n", b64));
-        DEBUGF("(ftch) using proxy authentication");
+    // Check for unix:// scheme
+    if (proxyurl.scheme.n == 4 &&
+        !memcasecmp(proxyurl.scheme.p, "unix", 4)) {
+      proxyunix = true;
+      // Path is in url path, e.g. unix:///tmp/proxy.sock
+      if (proxyurl.path.n) {
+        proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
+      } else {
+        return LuaNilError(L, "bad unix proxy; missing socket path");
       }
+      DEBUGF("(ftch) using unix proxy %s", proxysockpath);
+      // Disable keepalive when using proxy for simplicity
+      keepalive = kaNONE;
+    } else if (proxyurl.scheme.n == 4 &&
+               !memcasecmp(proxyurl.scheme.p, "http", 4)) {
+      if (!proxyurl.host.n) {
+        return LuaNilError(L, "bad proxy; missing host");
+      }
+      proxyhost = gc(strndup(proxyurl.host.p, proxyurl.host.n));
+      if (proxyurl.port.n) {
+        proxyport = gc(strndup(proxyurl.port.p, proxyurl.port.n));
+      } else {
+        proxyport = "80";
+      }
+      if (!IsAcceptableHost(proxyhost, -1)) {
+        return LuaNilError(L, "bad proxy; invalid host");
+      }
+      if (!IsAcceptablePort(proxyport, -1)) {
+        return LuaNilError(L, "bad proxy; invalid port");
+      }
+      DEBUGF("(ftch) using proxy %s:%s", proxyhost, proxyport);
+      // Disable keepalive when using proxy for simplicity
+      keepalive = kaNONE;
+      // Build Proxy-Authorization header if credentials present
+      if (proxyurl.user.n) {
+        char *creds = gc(xasprintf("%.*s:%.*s",
+                                   (int)proxyurl.user.n, proxyurl.user.p,
+                                   (int)proxyurl.pass.n, proxyurl.pass.p));
+        size_t credslen = strlen(creds);
+        char *b64 = gc(EncodeBase64(creds, credslen, 0));
+        if (b64) {
+          proxyauthhdr = gc(xasprintf("Proxy-Authorization: Basic %s\r\n", b64));
+          DEBUGF("(ftch) using proxy authentication");
+        }
+      }
+    } else {
+      return LuaNilError(L, "bad proxy scheme; only http:// and unix:// supported");
     }
   }
 
@@ -347,7 +362,22 @@ int LuaFetch(lua_State *L) {
   requestlen = appendz(request).i;
   gc(request);
 
-  if (keepalive == kaNONE || keepalive == kaOPEN) {
+  if (proxyunix) {
+    /*
+     * Connect via Unix domain socket proxy.
+     */
+    struct sockaddr_un addr_un = {.sun_family = AF_UNIX};
+    strlcpy(addr_un.sun_path, proxysockpath, sizeof(addr_un.sun_path));
+    DEBUGF("(ftch) client connecting to unix:%s", proxysockpath);
+    if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+      return LuaNilError(L, "socket(AF_UNIX) failed: %s", strerror(errno));
+    }
+    if (connect(sock, (struct sockaddr *)&addr_un, sizeof(addr_un)) == -1) {
+      close(sock);
+      return LuaNilError(L, "connect(%s) failed: %s", proxysockpath,
+                         strerror(errno));
+    }
+  } else if (keepalive == kaNONE || keepalive == kaOPEN) {
     /*
      * Perform DNS lookup.
      * When using a proxy, resolve the proxy host instead of target.
@@ -393,7 +423,7 @@ int LuaFetch(lua_State *L) {
   /*
    * For HTTPS through proxy, establish CONNECT tunnel first.
    */
-  if (usingssl && proxyhost) {
+  if (usingssl && (proxyhost || proxyunix)) {
     char *connectreq = 0;
     struct Buffer connectbuf = {0};
     struct HttpMessage connectmsg;

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -233,11 +233,14 @@ int LuaFetch(lua_State *L) {
         !memcasecmp(proxyurl.scheme.p, "unix", 4)) {
       proxyunix = true;
       // Path is in url path, e.g. unix:///tmp/proxy.sock
-      if (proxyurl.path.n) {
-        proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
-      } else {
+      if (!proxyurl.path.n) {
         return LuaNilError(L, "bad unix proxy; missing socket path");
       }
+      if (proxyurl.path.n >= sizeof(((struct sockaddr_un *)0)->sun_path)) {
+        return LuaNilError(L, "bad unix proxy; socket path too long (max %zu)",
+                           sizeof(((struct sockaddr_un *)0)->sun_path) - 1);
+      }
+      proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
       DEBUGF("(ftch) using unix proxy %s", proxysockpath);
       // Disable keepalive when using proxy for simplicity
       keepalive = kaNONE;

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -328,7 +328,7 @@ int LuaFetch(lua_State *L) {
   url.pass.p = 0, url.pass.n = 0;
   // For HTTP proxy requests, keep scheme/host/port for absolute URL
   // For direct or HTTPS-through-proxy, clear them
-  if (!proxyhost || usingssl) {
+  if ((!proxyhost && !proxyunix) || usingssl) {
     url.scheme.p = 0, url.scheme.n = 0;
     url.host.p = 0, url.host.n = 0;
     url.port.p = 0, url.port.n = 0;
@@ -356,7 +356,7 @@ int LuaFetch(lua_State *L) {
               ? "close"
               : (connhdr ? connhdr : "keep-alive"),
           agenthdr, conlenhdr,
-          (proxyhost && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
+          ((proxyhost || proxyunix) && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
           headers ? headers : "");
   appendd(&request, body, bodylen);
   requestlen = appendz(request).i;
@@ -364,9 +364,8 @@ int LuaFetch(lua_State *L) {
 
   if (proxyunix) {
     /*
-     * Connect via Unix domain socket.
-     * The socket is the HTTP server itself (not a forward proxy),
-     * so TLS handshake (if needed) happens directly on this fd.
+     * Connect to proxy via Unix domain socket.
+     * Same HTTP proxy semantics as TCP (absolute URLs, CONNECT for HTTPS).
      */
     struct sockaddr_un addr_un = {.sun_family = AF_UNIX};
     strlcpy(addr_un.sun_path, proxysockpath, sizeof(addr_un.sun_path));
@@ -425,7 +424,7 @@ int LuaFetch(lua_State *L) {
   /*
    * For HTTPS through proxy, establish CONNECT tunnel first.
    */
-  if (usingssl && proxyhost) {
+  if (usingssl && (proxyhost || proxyunix)) {
     char *connectreq = 0;
     struct Buffer connectbuf = {0};
     struct HttpMessage connectmsg;

--- a/tool/net/fetch.inc
+++ b/tool/net/fetch.inc
@@ -364,7 +364,9 @@ int LuaFetch(lua_State *L) {
 
   if (proxyunix) {
     /*
-     * Connect via Unix domain socket proxy.
+     * Connect via Unix domain socket.
+     * The socket is the HTTP server itself (not a forward proxy),
+     * so TLS handshake (if needed) happens directly on this fd.
      */
     struct sockaddr_un addr_un = {.sun_family = AF_UNIX};
     strlcpy(addr_un.sun_path, proxysockpath, sizeof(addr_un.sun_path));
@@ -423,7 +425,7 @@ int LuaFetch(lua_State *L) {
   /*
    * For HTTPS through proxy, establish CONNECT tunnel first.
    */
-  if (usingssl && (proxyhost || proxyunix)) {
+  if (usingssl && proxyhost) {
     char *connectreq = 0;
     struct Buffer connectbuf = {0};
     struct HttpMessage connectmsg;

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -767,6 +767,9 @@ int LuaFetchStream(lua_State *L) {
         return LuaNilError(L, "bad unix proxy; socket path too long (max %zu)",
                            sizeof(((struct sockaddr_un *)0)->sun_path) - 1);
       }
+      if (!IsReasonablePath(proxyurl.path.p, proxyurl.path.n)) {
+        return LuaNilError(L, "bad unix proxy; path contains . or .. segments");
+      }
       proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
       DEBUGF("(ftch) using unix proxy %s", proxysockpath);
     } else if (proxyurl.scheme.n == 4 &&
@@ -844,7 +847,7 @@ int LuaFetchStream(lua_State *L) {
           "\r\n",
           method, gc(EncodeUrl(&url, 0)), hosthdr,
           agenthdr, conlenhdr,
-          ((proxyhost || proxyunix) && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
+          (proxyhost && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
           headers ? headers : "");
   appendd(&request, body, bodylen);
   requestlen = appendz(request).i;

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -760,11 +760,15 @@ int LuaFetchStream(lua_State *L) {
         !memcasecmp(proxyurl.scheme.p, "unix", 4)) {
       proxyunix = true;
       // Path is in url path, e.g. unix:///tmp/proxy.sock
-      if (proxyurl.path.n) {
-        proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
-      } else {
+      if (!proxyurl.path.n) {
         return LuaNilError(L, "bad unix proxy; missing socket path");
       }
+      if (proxyurl.path.n >= sizeof(((struct sockaddr_un *)0)->sun_path)) {
+        return LuaNilError(L, "bad unix proxy; socket path too long (max %zu)",
+                           sizeof(((struct sockaddr_un *)0)->sun_path) - 1);
+      }
+      proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
+      DEBUGF("(ftch) using unix proxy %s", proxysockpath);
     } else if (proxyurl.scheme.n == 4 &&
                !memcasecmp(proxyurl.scheme.p, "http", 4)) {
       if (!proxyurl.host.n)

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -30,6 +30,7 @@
 #include "libc/serialize.h"
 #include "libc/sock/goodsocket.internal.h"
 #include "libc/sock/sock.h"
+#include "libc/sock/struct/sockaddr.h"
 #include "libc/stdio/append.h"
 #include "libc/str/slice.h"
 #include "libc/str/str.h"
@@ -600,6 +601,8 @@ int LuaFetchStream(lua_State *L) {
   const char *proxyarg = 0;
   size_t proxyarglen = 0;
   char *proxyauthhdr = 0;
+  bool proxyunix = false;
+  char *proxysockpath = NULL;
   char *request;
   struct TlsBio *bio;
   mbedtls_ssl_context *sslctx = NULL;
@@ -752,27 +755,38 @@ int LuaFetchStream(lua_State *L) {
   if (proxyarg && proxyarglen) {
     gc(ParseUrl(proxyarg, proxyarglen, &proxyurl, true));
     gc(proxyurl.params.p);
-    if (!(proxyurl.scheme.n == 4 &&
-          !memcasecmp(proxyurl.scheme.p, "http", 4))) {
-      return LuaNilError(L, "bad proxy scheme; only http:// proxies supported");
-    }
-    if (!proxyurl.host.n)
-      return LuaNilError(L, "bad proxy; missing host");
-    proxyhost = gc(strndup(proxyurl.host.p, proxyurl.host.n));
-    proxyport = proxyurl.port.n
-                    ? gc(strndup(proxyurl.port.p, proxyurl.port.n))
-                    : "80";
-    if (!IsAcceptableHost(proxyhost, -1))
-      return LuaNilError(L, "bad proxy; invalid host");
-    if (!IsAcceptablePort(proxyport, -1))
-      return LuaNilError(L, "bad proxy; invalid port");
-    if (proxyurl.user.n) {
-      char *creds = gc(xasprintf("%.*s:%.*s",
-                                 (int)proxyurl.user.n, proxyurl.user.p,
-                                 (int)proxyurl.pass.n, proxyurl.pass.p));
-      char *b64 = gc(EncodeBase64(creds, strlen(creds), 0));
-      if (b64)
-        proxyauthhdr = gc(xasprintf("Proxy-Authorization: Basic %s\r\n", b64));
+    // Check for unix:// scheme
+    if (proxyurl.scheme.n == 4 &&
+        !memcasecmp(proxyurl.scheme.p, "unix", 4)) {
+      proxyunix = true;
+      // Path is in url path, e.g. unix:///tmp/proxy.sock
+      if (proxyurl.path.n) {
+        proxysockpath = gc(strndup(proxyurl.path.p, proxyurl.path.n));
+      } else {
+        return LuaNilError(L, "bad unix proxy; missing socket path");
+      }
+    } else if (proxyurl.scheme.n == 4 &&
+               !memcasecmp(proxyurl.scheme.p, "http", 4)) {
+      if (!proxyurl.host.n)
+        return LuaNilError(L, "bad proxy; missing host");
+      proxyhost = gc(strndup(proxyurl.host.p, proxyurl.host.n));
+      proxyport = proxyurl.port.n
+                      ? gc(strndup(proxyurl.port.p, proxyurl.port.n))
+                      : "80";
+      if (!IsAcceptableHost(proxyhost, -1))
+        return LuaNilError(L, "bad proxy; invalid host");
+      if (!IsAcceptablePort(proxyport, -1))
+        return LuaNilError(L, "bad proxy; invalid port");
+      if (proxyurl.user.n) {
+        char *creds = gc(xasprintf("%.*s:%.*s",
+                                   (int)proxyurl.user.n, proxyurl.user.p,
+                                   (int)proxyurl.pass.n, proxyurl.pass.p));
+        char *b64 = gc(EncodeBase64(creds, strlen(creds), 0));
+        if (b64)
+          proxyauthhdr = gc(xasprintf("Proxy-Authorization: Basic %s\r\n", b64));
+      }
+    } else {
+      return LuaNilError(L, "bad proxy scheme; only http:// and unix:// supported");
     }
   }
 
@@ -833,7 +847,18 @@ int LuaFetchStream(lua_State *L) {
   gc(request);
 
   // ---- Connect ----
-  {
+  if (proxyunix) {
+    // Unix socket connection
+    struct sockaddr_un addr_un = {.sun_family = AF_UNIX};
+    strlcpy(addr_un.sun_path, proxysockpath, sizeof(addr_un.sun_path));
+    if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+      return LuaNilError(L, "socket(AF_UNIX) failed: %s", strerror(errno));
+    if (connect(sock, (struct sockaddr *)&addr_un, sizeof(addr_un)) == -1) {
+      close(sock);
+      return LuaNilError(L, "connect(%s) failed: %s", proxysockpath,
+                         strerror(errno));
+    }
+  } else {
     const char *connecthost = proxyhost ? proxyhost : host;
     const char *connectport = proxyhost ? proxyport : port;
     if ((rc = getaddrinfo(connecthost, connectport, &hints, &addr)) != 0)
@@ -860,7 +885,7 @@ int LuaFetchStream(lua_State *L) {
   (void)bio;
 #ifndef UNSECURE
   // ---- HTTPS proxy CONNECT tunnel ----
-  if (usingssl && proxyhost) {
+  if (usingssl && (proxyhost || proxyunix)) {
     char *connectreq = 0;
     struct Buffer connectbuf = {0};
     struct HttpMessage connectmsg;

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -848,7 +848,8 @@ int LuaFetchStream(lua_State *L) {
 
   // ---- Connect ----
   if (proxyunix) {
-    // Unix socket connection
+    // Unix domain socket connection - socket is the HTTP server itself,
+    // so TLS handshake (if needed) happens directly on this fd.
     struct sockaddr_un addr_un = {.sun_family = AF_UNIX};
     strlcpy(addr_un.sun_path, proxysockpath, sizeof(addr_un.sun_path));
     if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
@@ -885,7 +886,7 @@ int LuaFetchStream(lua_State *L) {
   (void)bio;
 #ifndef UNSECURE
   // ---- HTTPS proxy CONNECT tunnel ----
-  if (usingssl && (proxyhost || proxyunix)) {
+  if (usingssl && proxyhost) {
     char *connectreq = 0;
     struct Buffer connectbuf = {0};
     struct HttpMessage connectmsg;

--- a/tool/net/lfetch.c
+++ b/tool/net/lfetch.c
@@ -817,7 +817,7 @@ int LuaFetchStream(lua_State *L) {
   url.fragment.p = 0, url.fragment.n = 0;
   url.user.p = 0, url.user.n = 0;
   url.pass.p = 0, url.pass.n = 0;
-  if (!proxyhost || usingssl) {
+  if ((!proxyhost && !proxyunix) || usingssl) {
     url.scheme.p = 0, url.scheme.n = 0;
     url.host.p = 0, url.host.n = 0;
     url.port.p = 0, url.port.n = 0;
@@ -840,7 +840,7 @@ int LuaFetchStream(lua_State *L) {
           "\r\n",
           method, gc(EncodeUrl(&url, 0)), hosthdr,
           agenthdr, conlenhdr,
-          (proxyhost && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
+          ((proxyhost || proxyunix) && !usingssl && proxyauthhdr) ? proxyauthhdr : "",
           headers ? headers : "");
   appendd(&request, body, bodylen);
   requestlen = appendz(request).i;
@@ -848,8 +848,8 @@ int LuaFetchStream(lua_State *L) {
 
   // ---- Connect ----
   if (proxyunix) {
-    // Unix domain socket connection - socket is the HTTP server itself,
-    // so TLS handshake (if needed) happens directly on this fd.
+    // Connect to proxy via Unix domain socket.
+    // Same HTTP proxy semantics as TCP (absolute URLs, CONNECT for HTTPS).
     struct sockaddr_un addr_un = {.sun_family = AF_UNIX};
     strlcpy(addr_un.sun_path, proxysockpath, sizeof(addr_un.sun_path));
     if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
@@ -886,7 +886,7 @@ int LuaFetchStream(lua_State *L) {
   (void)bio;
 #ifndef UNSECURE
   // ---- HTTPS proxy CONNECT tunnel ----
-  if (usingssl && proxyhost) {
+  if (usingssl && (proxyhost || proxyunix)) {
     char *connectreq = 0;
     struct Buffer connectbuf = {0};
     struct HttpMessage connectmsg;


### PR DESCRIPTION
Add support for unix:// scheme in the proxy option for both Fetch() and
FetchStream(). This allows connecting to HTTP services via Unix domain
sockets (e.g. proxy="unix:///tmp/proxy.sock").

## Changes

- Parse unix:// proxy URLs, extracting socket path from URL path
- Create AF_UNIX socket and connect to the socket path
- Support HTTPS through unix proxy via CONNECT tunnel
- Update error messages to mention unix:// as supported scheme
- Add sockaddr.h include for struct sockaddr_un

## Security hardening

- Validate socket path length to prevent silent truncation by strlcpy
  (paths >= 108 bytes now return a clear error)
- Validate path with IsReasonablePath to reject . and .. segments
  (prevents path traversal attacks)

## Code quality

- Add DEBUGF logging for unix proxy in FetchStream (was missing)
- Fix dead code: proxyauthhdr condition now only checks HTTP proxies
- Add test coverage for all error cases (8 tests)

## Test plan

- [x] `make o//tool/lua/test_fetch_unix_proxy.ok` passes
- [x] Tests cover: missing path, path too long, path traversal, socket not found
- [x] Tests cover both Fetch and FetchStream