### PR TITLE
tests: add missing tests for tcgetattr/tcsetattr, exec*, daemon, pars…

### DIFF
--- a/test/net/http/parsehttpmessage_test.c
+++ b/test/net/http/parsehttpmessage_test.c
@@ -435,6 +435,64 @@ TEST(ParseHttpResponse, testHttp100) {
   EXPECT_EQ(10, req->version);
 }
 
+TEST(ParseHttpMessage, testBufferClampOnResume) {
+  // Verify that the parser clamps r->i correctly when pausing at the
+  // buffer boundary, so that resumption doesn't skip a byte. The inner
+  // loops may set r->i = n, then the outer for loop increments to n+1.
+  // Without the clamping fix, the first byte of new data gets skipped.
+  static const char m[] = "GET /hello HTTP/1.0\r\nHost: x\r\n\r\n";
+  size_t total = strlen(m);
+
+  // Feed the message one byte at a time to exercise boundary clamping.
+  // Each call except the last should return 0 (incomplete).
+  InitHttpMessage(req, kHttpRequest);
+  for (size_t i = 1; i <= total; i++) {
+    int rc = ParseHttpMessage(req, m, i, total);
+    if (i < total) {
+      EXPECT_EQ(0, rc);
+      // After returning 0, r->i must not exceed the number of bytes
+      // available (i), since we need to re-examine the last byte on
+      // the next call when more data is available.
+      EXPECT_LE(req->i, (int)i);
+    } else {
+      EXPECT_EQ((int)total, rc);
+    }
+  }
+  EXPECT_STREQ("GET", method());
+  EXPECT_STREQ("/hello", gc(slice(m, req->uri)));
+  EXPECT_EQ(10, req->version);
+  EXPECT_STREQ("x", gc(slice(m, req->headers[kHttpHost])));
+}
+
+TEST(ParseHttpMessage, testResumeAfterPartialMethod) {
+  // Feed a request where the method is split across two calls.
+  // This exercises the kHttpStateMethod inner loop boundary.
+  static const char m[] = "POST /data HTTP/1.1\r\n\r\n";
+  size_t total = strlen(m);
+  InitHttpMessage(req, kHttpRequest);
+  // First call: only "POS" available
+  EXPECT_EQ(0, ParseHttpMessage(req, m, 3, total));
+  EXPECT_LE(req->i, 3);
+  // Second call: full message available
+  EXPECT_EQ((int)total, ParseHttpMessage(req, m, total, total));
+  EXPECT_STREQ("POST", method());
+  EXPECT_STREQ("/data", gc(slice(m, req->uri)));
+}
+
+TEST(ParseHttpMessage, testResumeAfterPartialHeaderValue) {
+  // Feed a request where a header value is split at the boundary.
+  static const char m[] = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+  size_t total = strlen(m);
+  InitHttpMessage(req, kHttpRequest);
+  // Feed up to partway through "example.com" value
+  size_t partial = 25; // "GET / HTTP/1.1\r\nHost: exa"
+  EXPECT_EQ(0, ParseHttpMessage(req, m, partial, total));
+  EXPECT_LE(req->i, (int)partial);
+  // Feed the rest
+  EXPECT_EQ((int)total, ParseHttpMessage(req, m, total, total));
+  EXPECT_STREQ("example.com", gc(slice(m, req->headers[kHttpHost])));
+}
+
 TEST(ParseHttpMessage, issue1315) {
   static const char m[] = "\
 HTTP/1.1 200 OK\r\n\

--- a/test/net/https/getsslroots_test.c
+++ b/test/net/https/getsslroots_test.c
@@ -1,0 +1,63 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2024 Will Maier                                                    │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/testlib/testlib.h"
+#include "net/https/https.h"
+#include "third_party/mbedtls/x509_crt.h"
+
+// Test that GetSslRoots returns a non-NULL certificate chain.
+// The embedded certificates in /zip/usr/share/ssl/root should always
+// be available, so the chain should have at least one certificate.
+TEST(GetSslRoots, testReturnsNonNull) {
+  mbedtls_x509_crt *roots = GetSslRoots();
+  ASSERT_NE(NULL, roots);
+}
+
+// Test that the returned chain contains at least one parsed certificate.
+// The raw_len field is non-zero for a valid parsed certificate.
+TEST(GetSslRoots, testContainsCertificates) {
+  mbedtls_x509_crt *roots = GetSslRoots();
+  ASSERT_NE(NULL, roots);
+  // A valid parsed cert has non-zero raw.len
+  EXPECT_GT(roots->raw.len, 0u);
+}
+
+// Test that GetSslRoots is idempotent (singleton pattern).
+// Multiple calls should return the same pointer.
+TEST(GetSslRoots, testIsSingleton) {
+  mbedtls_x509_crt *roots1 = GetSslRoots();
+  mbedtls_x509_crt *roots2 = GetSslRoots();
+  ASSERT_EQ(roots1, roots2);
+}
+
+// Test that the certificate chain has valid structure.
+// Walk the chain and verify each cert has non-zero raw data.
+TEST(GetSslRoots, testChainStructure) {
+  mbedtls_x509_crt *roots = GetSslRoots();
+  ASSERT_NE(NULL, roots);
+  int count = 0;
+  for (mbedtls_x509_crt *cert = roots; cert != NULL; cert = cert->next) {
+    if (cert->raw.len > 0) {
+      count++;
+      // Each cert should have a non-empty subject
+      EXPECT_GT(cert->subject_raw.len, 0u);
+    }
+  }
+  // We expect at least a few root certificates from the embedded bundle
+  EXPECT_GT(count, 0);
+}

--- a/test/tool/net/BUILD.mk
+++ b/test/tool/net/BUILD.mk
@@ -91,6 +91,15 @@ o/$(MODE)/test/tool/net/lfetch_test.lua.runs:			\
 o/$(MODE)/test/tool/net/lfetchstream_test.lua.runs:		\
 		private .PLEDGE = stdio rpath inet proc
 
+o/$(MODE)/test/tool/net/tcattr_test.lua.runs:			\
+		private .PLEDGE = stdio rpath tty
+
+o/$(MODE)/test/tool/net/execvp_test.lua.runs:			\
+		private .PLEDGE = stdio rpath proc exec
+
+o/$(MODE)/test/tool/net/daemon_test.lua.runs:			\
+		private .PLEDGE = stdio rpath wpath cpath proc
+
 o/$(MODE)/test/tool/net/sqlite_test.runs:			\
 		private .PLEDGE = flock
 

--- a/test/tool/net/daemon_test.lua
+++ b/test/tool/net/daemon_test.lua
@@ -1,0 +1,67 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Tests for unix.daemon()
+
+-- Test function existence
+assert(type(unix.daemon) == "function", "daemon should be a function")
+
+-- Test daemon in a forked child process.
+-- daemon() forks internally so we must test it in a child to avoid
+-- daemonizing the test runner itself.
+local tmpdir = "/tmp/daemon_test_" .. tostring(unix.getpid())
+unix.makedirs(tmpdir, 0x1ED) -- 0755
+
+local marker = tmpdir .. "/daemon_ran"
+
+local pid = unix.fork()
+if pid == 0 then
+  -- child: daemonize with nochdir=true, noclose=true
+  local ok, err = unix.daemon(true, true)
+  if ok then
+    -- write a marker file to prove we ran after daemonizing
+    local fd = unix.open(marker, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, 0x1A4) -- 0644
+    if fd then
+      unix.write(fd, "ok")
+      unix.close(fd)
+    end
+  end
+  unix.exit(0)
+elseif pid then
+  -- parent: wait for the original child (which exits after daemon() forks)
+  local wpid, wstatus = unix.wait(pid)
+  assert(wpid == pid, "wait should return the forked pid")
+  assert(unix.WIFEXITED(wstatus), "child should exit normally")
+
+  -- Give the daemon child a moment to write its marker file
+  unix.nanosleep(0, 200000000) -- 200ms
+
+  -- Check that the daemon child ran and wrote its marker
+  local fd = unix.open(marker, unix.O_RDONLY)
+  if fd then
+    local content = unix.read(fd, 16)
+    unix.close(fd)
+    assert(content == "ok", "daemon child should have written marker, got: " .. tostring(content))
+    unix.unlink(marker)
+  else
+    -- The daemon may have been too slow or environment doesn't support it
+    print("warning: daemon marker file not found (may be expected in some environments)")
+  end
+end
+
+-- cleanup
+unix.rmdir(tmpdir)
+
+print("all daemon tests passed")

--- a/test/tool/net/execvp_test.lua
+++ b/test/tool/net/execvp_test.lua
@@ -1,0 +1,126 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Tests for unix.execvp(), unix.execvpe(), and unix.fexecve()
+
+-- Test function existence
+assert(type(unix.execvp) == "function", "execvp should be a function")
+assert(type(unix.execvpe) == "function", "execvpe should be a function")
+assert(type(unix.fexecve) == "function", "fexecve should be a function")
+
+-- Test execvp error case: nonexistent command
+local ok, err = unix.execvp("nonexistent_command_12345")
+assert(ok == nil, "execvp of nonexistent command should fail")
+assert(err ~= nil, "execvp failure should return error")
+
+-- Test execvp with argv error case
+local ok, err = unix.execvp("nonexistent_command_12345", {"nonexistent_command_12345"})
+assert(ok == nil, "execvp with argv of nonexistent command should fail")
+assert(err ~= nil, "execvp with argv failure should return error")
+
+-- Test execvpe error case: nonexistent command
+local ok, err = unix.execvpe("nonexistent_command_12345", {"nonexistent_command_12345"})
+assert(ok == nil, "execvpe of nonexistent command should fail")
+assert(err ~= nil, "execvpe failure should return error")
+
+-- Test execvpe error case with custom environment
+local ok, err = unix.execvpe("nonexistent_command_12345",
+  {"nonexistent_command_12345"}, {"PATH=/nonexistent"})
+assert(ok == nil, "execvpe with custom env of nonexistent command should fail")
+assert(err ~= nil, "execvpe with custom env failure should return error")
+
+-- Test fexecve error case: invalid fd
+local ok, err = unix.fexecve(999999, {"test"})
+assert(ok == nil, "fexecve with invalid fd should fail")
+assert(err ~= nil, "fexecve failure should return error")
+
+-- Test fexecve error case with custom environment
+local ok, err = unix.fexecve(999999, {"test"}, {"PATH=/bin"})
+assert(ok == nil, "fexecve with custom env and invalid fd should fail")
+assert(err ~= nil, "fexecve with custom env failure should return error")
+
+-- Test execvp in a forked child process (actual exec replacement)
+local true_path = unix.commandv("true")
+if true_path then
+  local pid = unix.fork()
+  if pid == 0 then
+    -- child: exec into /bin/true
+    unix.execvp(true_path, {true_path})
+    -- if we get here, exec failed
+    unix.exit(1)
+  elseif pid then
+    local wpid, wstatus = unix.wait(pid)
+    assert(wpid == pid, "wait should return the forked pid")
+    assert(unix.WIFEXITED(wstatus), "child should exit normally after execvp")
+    assert(unix.WEXITSTATUS(wstatus) == 0, "execvp'd true should exit 0")
+  end
+end
+
+-- Test execvpe in a forked child with custom environment
+local echo_path = unix.commandv("sh")
+if echo_path then
+  -- Use sh -c 'exit $MY_EXIT_CODE' to test environment passing
+  local pid = unix.fork()
+  if pid == 0 then
+    unix.execvpe("sh", {"sh", "-c", "exit ${MY_EXIT_CODE:-1}"},
+      {"MY_EXIT_CODE=42", "PATH=/bin:/usr/bin"})
+    unix.exit(1)
+  elseif pid then
+    local wpid, wstatus = unix.wait(pid)
+    assert(wpid == pid, "wait should return the forked pid")
+    assert(unix.WIFEXITED(wstatus), "child should exit normally after execvpe")
+    assert(unix.WEXITSTATUS(wstatus) == 42,
+      "execvpe should pass custom environment, got exit " ..
+      tostring(unix.WEXITSTATUS(wstatus)))
+  end
+end
+
+-- Test fexecve in a forked child process
+if true_path then
+  local fd = unix.open(true_path, unix.O_RDONLY)
+  if fd then
+    local pid = unix.fork()
+    if pid == 0 then
+      unix.fexecve(fd, {true_path})
+      unix.exit(1)
+    elseif pid then
+      local wpid, wstatus = unix.wait(pid)
+      assert(wpid == pid, "wait should return the forked pid")
+      -- fexecve may not work in all environments (e.g. noexec mounts)
+      -- so we just check the child exited
+      assert(unix.WIFEXITED(wstatus), "child should exit after fexecve attempt")
+    end
+    unix.close(fd)
+  end
+end
+
+-- Test execvp with multiple arguments in a forked child
+local sh_path = unix.commandv("sh")
+if sh_path then
+  local pid = unix.fork()
+  if pid == 0 then
+    unix.execvp(sh_path, {sh_path, "-c", "exit 7"})
+    unix.exit(1)
+  elseif pid then
+    local wpid, wstatus = unix.wait(pid)
+    assert(wpid == pid, "wait should return the forked pid")
+    assert(unix.WIFEXITED(wstatus), "child should exit normally")
+    assert(unix.WEXITSTATUS(wstatus) == 7,
+      "execvp'd sh -c 'exit 7' should exit 7, got " ..
+      tostring(unix.WEXITSTATUS(wstatus)))
+  end
+end
+
+print("all execvp/execvpe/fexecve tests passed")

--- a/test/tool/net/tcattr_test.lua
+++ b/test/tool/net/tcattr_test.lua
@@ -1,0 +1,141 @@
+-- Copyright 2024 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+-- Tests for unix.tcgetattr() and unix.tcsetattr()
+
+-- Test function existence
+assert(type(unix.tcgetattr) == "function", "tcgetattr should be a function")
+assert(type(unix.tcsetattr) == "function", "tcsetattr should be a function")
+
+-- Test constants exist
+assert(type(unix.TCSANOW) == "number", "TCSANOW should be a number")
+assert(type(unix.TCSADRAIN) == "number", "TCSADRAIN should be a number")
+assert(type(unix.TCSAFLUSH) == "number", "TCSAFLUSH should be a number")
+
+-- Test termios-related constants
+assert(type(unix.ECHO) == "number", "ECHO should be a number")
+assert(type(unix.ECHOE) == "number", "ECHOE should be a number")
+assert(type(unix.ECHOK) == "number", "ECHOK should be a number")
+assert(type(unix.ECHONL) == "number", "ECHONL should be a number")
+assert(type(unix.ICANON) == "number", "ICANON should be a number")
+assert(type(unix.ISIG) == "number", "ISIG should be a number")
+assert(type(unix.OPOST) == "number", "OPOST should be a number")
+assert(type(unix.CSIZE) == "number", "CSIZE should be a number")
+assert(type(unix.PARENB) == "number", "PARENB should be a number")
+assert(type(unix.VMIN) == "number", "VMIN should be a number")
+assert(type(unix.VTIME) == "number", "VTIME should be a number")
+assert(type(unix.NCCS) == "number", "NCCS should be a number")
+assert(unix.NCCS > 0, "NCCS should be positive")
+
+-- Test tcgetattr on a non-terminal fd (should fail with ENOTTY)
+local fd = unix.open("/dev/null", unix.O_RDONLY)
+assert(fd, "should be able to open /dev/null")
+local tio, err = unix.tcgetattr(fd)
+assert(tio == nil, "tcgetattr on /dev/null should fail")
+assert(err ~= nil, "tcgetattr should return error for non-tty")
+unix.close(fd)
+
+-- Test tcsetattr on a non-terminal fd (should fail)
+local fd = unix.open("/dev/null", unix.O_RDONLY)
+assert(fd, "should be able to open /dev/null")
+local ok, err = unix.tcsetattr(fd, unix.TCSANOW, {
+  iflag = 0,
+  oflag = 0,
+  cflag = 0,
+  lflag = 0,
+})
+assert(ok == nil, "tcsetattr on /dev/null should fail")
+assert(err ~= nil, "tcsetattr should return error for non-tty")
+unix.close(fd)
+
+-- Test tcgetattr on a pty if possible
+-- Open a pty master; if openpty or /dev/ptmx is available, test real attrs
+local pty_fd = unix.open("/dev/ptmx", unix.O_RDWR)
+if pty_fd then
+  local tio, err = unix.tcgetattr(pty_fd)
+  if tio then
+    -- Verify the returned table has the expected fields
+    assert(type(tio.iflag) == "number", "iflag should be a number")
+    assert(type(tio.oflag) == "number", "oflag should be a number")
+    assert(type(tio.cflag) == "number", "cflag should be a number")
+    assert(type(tio.lflag) == "number", "lflag should be a number")
+    assert(type(tio.cc) == "table", "cc should be a table")
+    assert(type(tio.ispeed) == "number", "ispeed should be a number")
+    assert(type(tio.ospeed) == "number", "ospeed should be a number")
+
+    -- Verify cc table has NCCS entries
+    local cc_count = 0
+    for i = 1, unix.NCCS do
+      assert(type(tio.cc[i]) == "number", "cc[" .. i .. "] should be a number")
+      cc_count = cc_count + 1
+    end
+    assert(cc_count == unix.NCCS, "cc should have NCCS entries")
+
+    -- Test tcsetattr with the same attributes (round-trip)
+    local ok, err = unix.tcsetattr(pty_fd, unix.TCSANOW, tio)
+    assert(ok == true, "tcsetattr should succeed on pty: " .. tostring(err))
+
+    -- Verify attributes can be read back
+    local tio2, err2 = unix.tcgetattr(pty_fd)
+    assert(tio2 ~= nil, "tcgetattr should succeed after tcsetattr: " .. tostring(err2))
+    assert(type(tio2.iflag) == "number", "iflag should persist")
+    assert(type(tio2.oflag) == "number", "oflag should persist")
+    assert(type(tio2.cflag) == "number", "cflag should persist")
+    assert(type(tio2.lflag) == "number", "lflag should persist")
+
+    -- Test modifying terminal attributes
+    local modified = {
+      iflag = tio.iflag,
+      oflag = tio.oflag,
+      cflag = tio.cflag,
+      lflag = tio.lflag & ~unix.ECHO,  -- disable echo
+      cc = tio.cc,
+      ispeed = tio.ispeed,
+      ospeed = tio.ospeed,
+    }
+    local ok, err = unix.tcsetattr(pty_fd, unix.TCSANOW, modified)
+    assert(ok == true, "tcsetattr with modified lflag should succeed: " .. tostring(err))
+
+    local tio3, err3 = unix.tcgetattr(pty_fd)
+    assert(tio3 ~= nil, "tcgetattr after modification should succeed: " .. tostring(err3))
+    -- Verify ECHO is disabled
+    assert(tio3.lflag & unix.ECHO == 0,
+      "ECHO should be disabled after tcsetattr")
+
+    -- Test tcsetattr with TCSADRAIN
+    local ok, err = unix.tcsetattr(pty_fd, unix.TCSADRAIN, tio)
+    assert(ok == true, "tcsetattr with TCSADRAIN should succeed: " .. tostring(err))
+
+    -- Test tcsetattr with TCSAFLUSH
+    local ok, err = unix.tcsetattr(pty_fd, unix.TCSAFLUSH, tio)
+    assert(ok == true, "tcsetattr with TCSAFLUSH should succeed: " .. tostring(err))
+
+    -- Test tcsetattr with partial table (missing fields default to 0)
+    local ok, err = unix.tcsetattr(pty_fd, unix.TCSANOW, {lflag = unix.ICANON})
+    assert(ok == true, "tcsetattr with partial table should succeed: " .. tostring(err))
+  else
+    print("tcgetattr on ptmx failed (may be expected in some environments): " .. tostring(err))
+  end
+  unix.close(pty_fd)
+else
+  print("skipping pty tests: could not open /dev/ptmx")
+end
+
+-- Test tcgetattr with invalid fd
+local tio, err = unix.tcgetattr(999999)
+assert(tio == nil, "tcgetattr on invalid fd should fail")
+assert(err ~= nil, "tcgetattr should return error for invalid fd")
+
+print("all tcattr tests passed")


### PR DESCRIPTION
…ehttpmessage resume, and SSL roots

Cover functionality added vs upstream that was missing test coverage:

- tcattr_test.lua: test unix.tcgetattr/tcsetattr on pty and non-tty fds, verify termios table structure, round-trip attributes, and ECHO toggle
- execvp_test.lua: test unix.execvp/execvpe/fexecve with fork+exec for successful execution, environment passing, and error cases
- daemon_test.lua: test unix.daemon() in forked child, verify marker file to confirm daemonized process ran
- parsehttpmessage_test.c: add tests for buffer position clamping fix on resume after incomplete parse (byte-at-a-time, partial method, partial header value)
- getsslroots_test.c: test GetSslRoots() returns non-NULL chain with valid certificates, verify singleton behavior and chain structure

https://claude.ai/code/session_01FcqRX33TVdN9HMo4Ay2iET