### PR TITLE
lua: add AeadEncrypt, AeadDecrypt, and Hkdf crypto functions

### DIFF
--- a/test/tool/net/lcrypto_test.lua
+++ b/test/tool/net/lcrypto_test.lua
@@ -1,0 +1,135 @@
+#!/usr/bin/env cosmic
+-- tests for AeadEncrypt, AeadDecrypt, and Hkdf
+
+local cosmo = require("cosmo")
+
+-- Helper: make a fresh 32-byte key
+local function make_key()
+  return cosmo.GetRandomBytes(32)
+end
+
+-- AeadEncrypt/AeadDecrypt round-trip
+local function test_aead_round_trip()
+  local key = make_key()
+  local plain = "hello, world"
+  local ct = assert(cosmo.AeadEncrypt(key, plain))
+  local pt = assert(cosmo.AeadDecrypt(key, ct))
+  assert(pt == plain, "round-trip mismatch: got " .. tostring(pt))
+end
+test_aead_round_trip()
+
+-- Different ciphertext each call (random nonce)
+local function test_aead_different_each_call()
+  local key = make_key()
+  local ct1 = assert(cosmo.AeadEncrypt(key, "same"))
+  local ct2 = assert(cosmo.AeadEncrypt(key, "same"))
+  assert(ct1 ~= ct2, "two encryptions should differ")
+end
+test_aead_different_each_call()
+
+-- Wrong key fails
+local function test_aead_wrong_key()
+  local ct = assert(cosmo.AeadEncrypt(make_key(), "secret"))
+  local pt, err = cosmo.AeadDecrypt(make_key(), ct)
+  assert(pt == nil, "wrong key should fail")
+  assert(err:find("authentication"), "error should mention auth: " .. tostring(err))
+end
+test_aead_wrong_key()
+
+-- Tampered ciphertext fails
+local function test_aead_tampered()
+  local key = make_key()
+  local ct = assert(cosmo.AeadEncrypt(key, "original"))
+  local tampered = ct:sub(1, -2) .. string.char(ct:byte(-1) ~ 0x01)
+  local pt, err = cosmo.AeadDecrypt(key, tampered)
+  assert(pt == nil, "tampered ciphertext should fail")
+end
+test_aead_tampered()
+
+-- Too short ciphertext
+local function test_aead_too_short()
+  local key = make_key()
+  local pt, err = cosmo.AeadDecrypt(key, "short")
+  assert(pt == nil, "too-short should fail")
+  assert(err:find("too short"), "error should mention too short: " .. tostring(err))
+end
+test_aead_too_short()
+
+-- Empty plaintext
+local function test_aead_empty()
+  local key = make_key()
+  local ct = assert(cosmo.AeadEncrypt(key, ""))
+  -- nonce(12) + tag(16) + 0 = 28
+  assert(#ct == 28, "empty ciphertext should be 28 bytes, got " .. #ct)
+  local pt = assert(cosmo.AeadDecrypt(key, ct))
+  assert(pt == "", "empty roundtrip should yield empty")
+end
+test_aead_empty()
+
+-- AAD: matching AAD decrypts
+local function test_aead_with_aad()
+  local key = make_key()
+  local ct = assert(cosmo.AeadEncrypt(key, "data", "context"))
+  local pt = assert(cosmo.AeadDecrypt(key, ct, "context"))
+  assert(pt == "data", "AAD round-trip mismatch")
+end
+test_aead_with_aad()
+
+-- AAD: wrong AAD fails
+local function test_aead_wrong_aad()
+  local key = make_key()
+  local ct = assert(cosmo.AeadEncrypt(key, "data", "correct"))
+  local pt, err = cosmo.AeadDecrypt(key, ct, "wrong")
+  assert(pt == nil, "wrong AAD should fail")
+end
+test_aead_wrong_aad()
+
+-- Ciphertext length
+local function test_aead_length()
+  local key = make_key()
+  local ct = assert(cosmo.AeadEncrypt(key, "test"))
+  -- nonce(12) + tag(16) + plaintext(4) = 32
+  assert(#ct == 32, "ciphertext should be 32 bytes, got " .. #ct)
+end
+test_aead_length()
+
+-- Hkdf basic
+local function test_hkdf_basic()
+  local key = cosmo.Hkdf("password", "salt", "info")
+  assert(key, "Hkdf should return a key")
+  assert(#key == 32, "default output should be 32 bytes, got " .. #key)
+end
+test_hkdf_basic()
+
+-- Hkdf deterministic
+local function test_hkdf_deterministic()
+  local k1 = cosmo.Hkdf("password", "salt", "info")
+  local k2 = cosmo.Hkdf("password", "salt", "info")
+  assert(k1 == k2, "same inputs should produce same output")
+end
+test_hkdf_deterministic()
+
+-- Hkdf different inputs produce different outputs
+local function test_hkdf_different_inputs()
+  local k1 = cosmo.Hkdf("password1", "salt", "info")
+  local k2 = cosmo.Hkdf("password2", "salt", "info")
+  assert(k1 ~= k2, "different passwords should produce different keys")
+end
+test_hkdf_different_inputs()
+
+-- Hkdf custom length
+local function test_hkdf_custom_length()
+  local key = cosmo.Hkdf("ikm", "salt", "info", 64)
+  assert(#key == 64, "custom length should be 64 bytes, got " .. #key)
+end
+test_hkdf_custom_length()
+
+-- Hkdf empty salt/info
+local function test_hkdf_empty_salt_info()
+  local key = cosmo.Hkdf("ikm", "", "")
+  assert(key, "empty salt/info should work")
+  assert(#key == 32, "should be 32 bytes")
+end
+test_hkdf_empty_salt_info()
+
+print("all crypto tests passed")

--- a/tool/net/BUILD.mk
+++ b/tool/net/BUILD.mk
@@ -95,6 +95,7 @@ o/$(MODE)/tool/net/%.dbg:						\
 # The little web server that could!
 
 TOOL_NET_REDBEAN_LUA_MODULES =						\
+	o/$(MODE)/tool/net/lcrypto.o					\
 	o/$(MODE)/tool/net/lfuncs.o					\
 	o/$(MODE)/tool/net/lpath.o					\
 	o/$(MODE)/tool/net/lhttp.o					\

--- a/tool/net/lcrypto.c
+++ b/tool/net/lcrypto.c
@@ -1,0 +1,220 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2024 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "tool/net/lcrypto.h"
+
+#include "libc/stdio/rand.h"
+#include "libc/str/str.h"
+#include "third_party/lua/lauxlib.h"
+#include "third_party/lua/lua.h"
+#include "third_party/mbedtls/chachapoly.h"
+#include "third_party/mbedtls/hkdf.h"
+#include "third_party/mbedtls/md.h"
+
+#define CHACHAPOLY_KEY_LEN  32
+#define CHACHAPOLY_NONCE_LEN 12
+#define CHACHAPOLY_TAG_LEN  16
+
+/**
+ * AeadEncrypt(key, plaintext[, aad]) → ciphertext
+ *
+ * Encrypts plaintext using ChaCha20-Poly1305 AEAD.
+ *
+ * @param key   32-byte encryption key (raw bytes)
+ * @param plaintext  data to encrypt
+ * @param aad   optional additional authenticated data
+ * @return nonce(12) || tag(16) || ciphertext on success
+ * @return nil, error on failure
+ */
+int LuaAeadEncrypt(lua_State *L) {
+  size_t kl, pl, al;
+  const char *key = luaL_checklstring(L, 1, &kl);
+  const char *plaintext = luaL_checklstring(L, 2, &pl);
+  const char *aad = luaL_optlstring(L, 3, "", &al);
+  int rc;
+  mbedtls_chachapoly_context ctx;
+
+  if (kl != CHACHAPOLY_KEY_LEN) {
+    return luaL_error(L, "key must be 32 bytes, got %d", (int)kl);
+  }
+
+  /* generate random nonce */
+  uint8_t nonce[CHACHAPOLY_NONCE_LEN];
+  if (getrandom(nonce, sizeof(nonce), 0) != sizeof(nonce)) {
+    lua_pushnil(L);
+    lua_pushstring(L, "failed to generate random nonce");
+    return 2;
+  }
+
+  /* allocate output buffer: nonce + tag + ciphertext */
+  size_t outlen = CHACHAPOLY_NONCE_LEN + CHACHAPOLY_TAG_LEN + pl;
+  uint8_t *out = lua_newuserdata(L, outlen);
+
+  /* copy nonce to output */
+  memcpy(out, nonce, CHACHAPOLY_NONCE_LEN);
+
+  /* encrypt */
+  mbedtls_chachapoly_init(&ctx);
+  rc = mbedtls_chachapoly_setkey(&ctx, (const unsigned char *)key);
+  if (rc != 0) {
+    mbedtls_chachapoly_free(&ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, "failed to set key");
+    return 2;
+  }
+
+  rc = mbedtls_chachapoly_encrypt_and_tag(&ctx,
+      pl,
+      nonce,
+      (const unsigned char *)aad, al,
+      (const unsigned char *)plaintext,
+      out + CHACHAPOLY_NONCE_LEN + CHACHAPOLY_TAG_LEN,  /* ciphertext */
+      out + CHACHAPOLY_NONCE_LEN);                       /* tag */
+
+  mbedtls_chachapoly_free(&ctx);
+
+  if (rc != 0) {
+    lua_pushnil(L);
+    lua_pushstring(L, "encryption failed");
+    return 2;
+  }
+
+  lua_pushlstring(L, (const char *)out, outlen);
+  return 1;
+}
+
+/**
+ * AeadDecrypt(key, ciphertext[, aad]) → plaintext
+ *
+ * Decrypts ciphertext produced by AeadEncrypt using ChaCha20-Poly1305.
+ *
+ * @param key   32-byte encryption key (raw bytes)
+ * @param data  nonce(12) || tag(16) || ciphertext
+ * @param aad   optional additional authenticated data
+ * @return plaintext on success
+ * @return nil, error on failure (including authentication failure)
+ */
+int LuaAeadDecrypt(lua_State *L) {
+  size_t kl, dl, al;
+  const char *key = luaL_checklstring(L, 1, &kl);
+  const char *data = luaL_checklstring(L, 2, &dl);
+  const char *aad = luaL_optlstring(L, 3, "", &al);
+  int rc;
+  mbedtls_chachapoly_context ctx;
+
+  if (kl != CHACHAPOLY_KEY_LEN) {
+    return luaL_error(L, "key must be 32 bytes, got %d", (int)kl);
+  }
+
+  size_t overhead = CHACHAPOLY_NONCE_LEN + CHACHAPOLY_TAG_LEN;
+  if (dl < overhead) {
+    lua_pushnil(L);
+    lua_pushstring(L, "ciphertext too short");
+    return 2;
+  }
+
+  const unsigned char *nonce = (const unsigned char *)data;
+  const unsigned char *tag = (const unsigned char *)data + CHACHAPOLY_NONCE_LEN;
+  const unsigned char *ct = (const unsigned char *)data + overhead;
+  size_t ct_len = dl - overhead;
+
+  /* allocate output buffer */
+  uint8_t *plaintext = lua_newuserdata(L, ct_len > 0 ? ct_len : 1);
+
+  mbedtls_chachapoly_init(&ctx);
+  rc = mbedtls_chachapoly_setkey(&ctx, (const unsigned char *)key);
+  if (rc != 0) {
+    mbedtls_chachapoly_free(&ctx);
+    lua_pushnil(L);
+    lua_pushstring(L, "failed to set key");
+    return 2;
+  }
+
+  rc = mbedtls_chachapoly_auth_decrypt(&ctx,
+      ct_len,
+      nonce,
+      (const unsigned char *)aad, al,
+      tag,
+      ct,
+      plaintext);
+
+  mbedtls_chachapoly_free(&ctx);
+
+  if (rc == MBEDTLS_ERR_CHACHAPOLY_AUTH_FAILED) {
+    lua_pushnil(L);
+    lua_pushstring(L, "authentication failed");
+    return 2;
+  }
+  if (rc != 0) {
+    lua_pushnil(L);
+    lua_pushstring(L, "decryption failed");
+    return 2;
+  }
+
+  lua_pushlstring(L, (const char *)plaintext, ct_len);
+  return 1;
+}
+
+/**
+ * Hkdf(ikm, salt, info[, length]) → okm
+ *
+ * Derives a key using HKDF-SHA256 (RFC 5869).
+ *
+ * @param ikm    input keying material (raw bytes)
+ * @param salt   salt value (raw bytes, can be empty string)
+ * @param info   context/application info (raw bytes, can be empty string)
+ * @param length desired output length in bytes (default 32, max 8160)
+ * @return derived key material on success
+ * @return nil, error on failure
+ */
+int LuaHkdf(lua_State *L) {
+  size_t ikm_len, salt_len, info_len;
+  const char *ikm = luaL_checklstring(L, 1, &ikm_len);
+  const char *salt = luaL_checklstring(L, 2, &salt_len);
+  const char *info = luaL_checklstring(L, 3, &info_len);
+  lua_Integer okm_len = luaL_optinteger(L, 4, 32);
+
+  if (okm_len < 1 || okm_len > 255 * 32) {
+    return luaL_error(L, "output length must be 1-%d, got %d",
+                      255 * 32, (int)okm_len);
+  }
+
+  const mbedtls_md_info_t *md = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  if (!md) {
+    lua_pushnil(L);
+    lua_pushstring(L, "SHA-256 not available");
+    return 2;
+  }
+
+  uint8_t *okm = lua_newuserdata(L, okm_len);
+
+  int rc = mbedtls_hkdf(md,
+      (const unsigned char *)salt, salt_len,
+      (const unsigned char *)ikm, ikm_len,
+      (const unsigned char *)info, info_len,
+      okm, okm_len);
+
+  if (rc != 0) {
+    lua_pushnil(L);
+    lua_pushfstring(L, "HKDF failed (error %d)", rc);
+    return 2;
+  }
+
+  lua_pushlstring(L, (const char *)okm, okm_len);
+  return 1;
+}

--- a/tool/net/lcrypto.h
+++ b/tool/net/lcrypto.h
@@ -1,0 +1,11 @@
+#ifndef COSMOPOLITAN_TOOL_NET_LCRYPTO_H_
+#define COSMOPOLITAN_TOOL_NET_LCRYPTO_H_
+#include "third_party/lua/lua.h"
+COSMOPOLITAN_C_START_
+
+int LuaAeadEncrypt(lua_State *);
+int LuaAeadDecrypt(lua_State *);
+int LuaHkdf(lua_State *);
+
+COSMOPOLITAN_C_END_
+#endif /* COSMOPOLITAN_TOOL_NET_LCRYPTO_H_ */

--- a/tool/net/redbean.c
+++ b/tool/net/redbean.c
@@ -132,6 +132,7 @@
 #include "third_party/zlib/zlib.h"
 #include "tool/build/lib/case.h"
 #include "tool/net/lfinger.h"
+#include "tool/net/lcrypto.h"
 #include "tool/net/lfuncs.h"
 #include "tool/net/ljson.h"
 #include "tool/net/lpath.h"
@@ -5013,6 +5014,8 @@ static const char *const kDontAutoComplete[] = {
 // </SORTED>
 
 static const luaL_Reg kLuaFuncs[] = {
+    {"AeadDecrypt", LuaAeadDecrypt},                            //
+    {"AeadEncrypt", LuaAeadEncrypt},                            //
     {"Barf", LuaBarf},                                          //
     {"Benchmark", LuaBenchmark},                                //
     {"Bsf", LuaBsf},                                            //
@@ -5094,6 +5097,7 @@ static const luaL_Reg kLuaFuncs[] = {
     {"HasParam", LuaHasParam},                                  //
     {"HidePath", LuaHidePath},                                  //
     {"HighwayHash64", LuaHighwayHash64},                        //
+    {"Hkdf", LuaHkdf},                                          //
     {"IndentLines", LuaIndentLines},                            //
     {"Inflate", LuaInflate},                                    //
     {"IsAcceptableHost", LuaIsAcceptableHost},                  //


### PR DESCRIPTION
Exposes ChaCha20-Poly1305 AEAD and HKDF-SHA256 from mbedtls to lua.

## New functions

| function | signature | description |
|----------|-----------|-------------|
| `AeadEncrypt` | `(key, plaintext[, aad]) → data` | ChaCha20-Poly1305 encrypt. returns `nonce(12) \|\| tag(16) \|\| ciphertext` |
| `AeadDecrypt` | `(key, data[, aad]) → plaintext` | ChaCha20-Poly1305 decrypt. returns `nil, "authentication failed"` on tamper |
| `Hkdf` | `(ikm, salt, info[, length]) → key` | HKDF-SHA256 (RFC 5869). default 32 bytes, max 8160 |

## Files

- `tool/net/lcrypto.c` — 3 lua functions wrapping mbedtls
- `tool/net/lcrypto.h` — declarations
- `tool/net/redbean.c` — registers functions in `kLuaFuncs`
- `tool/net/BUILD.mk` — adds `lcrypto.o` to redbean modules
- `test/tool/net/lcrypto_test.lua` — tests

## Motivation

cosmic's `cosmic.crypto` module currently builds HMAC-SHA256 byte-by-byte in pure lua, uses SHA256-CTR as a stream cipher, and implements HKDF in pure lua. These C primitives replace that with proper AEAD:

- `AeadEncrypt`/`AeadDecrypt` replaces HMAC + SHA256-CTR + constant-time compare with a single ChaCha20-Poly1305 call
- `Hkdf` replaces hand-rolled HKDF-extract + HKDF-expand
- Overhead drops from 48 bytes (16 nonce + 32 HMAC tag) to 28 bytes (12 nonce + 16 Poly1305 tag)

Closes whilp/cosmic#193