### PR TITLE
workflows: remove update-pr job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,20 +6,6 @@ on:
       - master
 
 jobs:
-  update-pr:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
-
-      - name: Update PR title and description
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          bin/cosmic --skill pr
-
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Remove the `update-pr` job from `.github/workflows/pr.yml` that invoked `bin/cosmic --skill pr` to auto-update PR title/description
- The `build` job is unchanged

## Test plan
- [ ] Confirm PR workflow still runs the `build` job on this PR