### PR TITLE
sandbox.proxy: add strict mode to validate allowlist rules

### DIFF
--- a/tool/lua/cosmo/sandbox/proxy.lua
+++ b/tool/lua/cosmo/sandbox/proxy.lua
@@ -173,6 +173,52 @@ local function auth_header(rule)
 end
 M._auth_header = auth_header
 
+-- Validate a single allowlist rule. Returns nil on success, a
+-- human-readable error string on failure. Used only when opts.strict
+-- is set; the default path stays tolerant for back-compat.
+--
+-- Bare pass-through values (nil, true, {}) are accepted as "allow,
+-- no auth injection". A table with a `type` field must use a known
+-- type and carry the fields that auth_header() would dereference.
+local function validate_rule(key, rule)
+  if rule == nil or rule == true then return nil end
+  if type(rule) ~= "table" then
+    return string.format("allowed_hosts[%q]: rule must be a table, true, "
+                         .. "or nil (got %s)", key, type(rule))
+  end
+  if rule.type == nil then return nil end   -- {} is explicit pass-through
+  if rule.type == "bearer" then
+    if type(rule.token) ~= "string" or rule.token == "" then
+      return string.format("allowed_hosts[%q]: bearer rule requires "
+                           .. "non-empty string `token`", key)
+    end
+  elseif rule.type == "basic" then
+    if type(rule.username) ~= "string" or rule.username == "" then
+      return string.format("allowed_hosts[%q]: basic rule requires "
+                           .. "non-empty string `username`", key)
+    end
+    if type(rule.password) ~= "string" then
+      return string.format("allowed_hosts[%q]: basic rule requires "
+                           .. "string `password`", key)
+    end
+  elseif rule.type == "header" then
+    if type(rule.header_name) ~= "string" or rule.header_name == "" then
+      return string.format("allowed_hosts[%q]: header rule requires "
+                           .. "non-empty string `header_name`", key)
+    end
+    if type(rule.header_value) ~= "string" then
+      return string.format("allowed_hosts[%q]: header rule requires "
+                           .. "string `header_value`", key)
+    end
+  else
+    return string.format("allowed_hosts[%q]: unknown rule type %q "
+                         .. "(expected \"bearer\", \"basic\", or \"header\")",
+                         key, tostring(rule.type))
+  end
+  return nil
+end
+M._validate_rule = validate_rule
+
 --------------------------------------------------------------------------------
 -- Wire I/O helpers
 
@@ -631,7 +677,9 @@ end
 ---     → "<header_name>: <header_value>"
 ---
 --- Unknown `type` values behave as pass-through. Rules are validated
---- lazily; unknown fields are ignored (forward compatibility).
+--- lazily; unknown fields are ignored (forward compatibility). Pass
+--- `opts.strict = true` to proxy.new / proxy.start to reject unknown
+--- types and missing required fields at construction time.
 
 local Proxy = {}
 Proxy.__index = Proxy
@@ -648,10 +696,21 @@ Proxy.__index = Proxy
 ---   log_format       "text"|"json"           (default "text")
 ---   log_file         path                    (default stderr)
 ---   accept_backlog   int                     (default 32)
+---   strict           boolean (default false) — when true, validate
+---                    every allowed_hosts rule at construction time
+---                    and raise on unknown rule types or missing
+---                    required fields. Recommended for new callers;
+---                    off by default so existing configs keep working.
 ---
 --- Returns the Proxy object.
 function M.new(opts)
   opts = opts or {}
+  if opts.strict then
+    for key, rule in pairs(opts.allowed_hosts or {}) do
+      local verr = validate_rule(key, rule)
+      if verr then error(verr) end
+    end
+  end
   local logger, lerr = make_logger(opts)
   if not logger then error(lerr) end
   return setmetatable({

--- a/tool/lua/cosmo/sandbox/proxy.lua
+++ b/tool/lua/cosmo/sandbox/proxy.lua
@@ -174,8 +174,10 @@ end
 M._auth_header = auth_header
 
 -- Validate a single allowlist rule. Returns nil on success, a
--- human-readable error string on failure. Used only when opts.strict
--- is set; the default path stays tolerant for back-compat.
+-- human-readable error string on failure. Invoked on every rule at
+-- proxy.new time so operators can't silently typo their way out of
+-- header injection — a sandbox proxy is security-sensitive and a
+-- misspelled `type` must fail loudly, not degrade to pass-through.
 --
 -- Bare pass-through values (nil, true, {}) are accepted as "allow,
 -- no auth injection". A table with a `type` field must use a known
@@ -676,10 +678,11 @@ end
 ---   type="header", header_name=STRING, header_value=STRING
 ---     → "<header_name>: <header_value>"
 ---
---- Unknown `type` values behave as pass-through. Rules are validated
---- lazily; unknown fields are ignored (forward compatibility). Pass
---- `opts.strict = true` to proxy.new / proxy.start to reject unknown
---- types and missing required fields at construction time.
+--- Every rule is validated at proxy.new time: unknown `type` values
+--- and missing required fields raise immediately. This is
+--- deliberate — a typo'd rule silently degrading to pass-through
+--- would strip auth from an otherwise-authenticated egress path.
+--- Unknown *non-type* fields are ignored (forward compatibility).
 
 local Proxy = {}
 Proxy.__index = Proxy
@@ -696,20 +699,16 @@ Proxy.__index = Proxy
 ---   log_format       "text"|"json"           (default "text")
 ---   log_file         path                    (default stderr)
 ---   accept_backlog   int                     (default 32)
----   strict           boolean (default false) — when true, validate
----                    every allowed_hosts rule at construction time
----                    and raise on unknown rule types or missing
----                    required fields. Recommended for new callers;
----                    off by default so existing configs keep working.
+---
+--- Raises if any allowed_hosts rule has an unknown `type` or is
+--- missing a required field — see "Allowlist rule schema" above.
 ---
 --- Returns the Proxy object.
 function M.new(opts)
   opts = opts or {}
-  if opts.strict then
-    for key, rule in pairs(opts.allowed_hosts or {}) do
-      local verr = validate_rule(key, rule)
-      if verr then error(verr) end
-    end
+  for key, rule in pairs(opts.allowed_hosts or {}) do
+    local verr = validate_rule(key, rule)
+    if verr then error(verr) end
   end
   local logger, lerr = make_logger(opts)
   if not logger then error(lerr) end

--- a/tool/lua/cosmo/sandbox/test_proxy.lua
+++ b/tool/lua/cosmo/sandbox/test_proxy.lua
@@ -232,4 +232,91 @@ do
   assertf(p._index, "index not built")
 end
 
+-- Strict mode: default (strict=false) silently tolerates typos so we
+-- don't break existing callers.
+do
+  local ok, p = pcall(proxy.new, {
+    log_level = "quiet",
+    allowed_hosts = {
+      ["api.example:443"] = {type = "Bearer", token = "x"},  -- typo
+    },
+  })
+  assertf(ok, "non-strict mode should accept unknown rule types: %s",
+          tostring(p))
+  assertf(type(p) == "table", "non-strict should still return proxy")
+end
+
+-- Strict mode: unknown rule.type is rejected at construction time.
+do
+  local ok, err = pcall(proxy.new, {
+    log_level = "quiet",
+    strict = true,
+    allowed_hosts = {
+      ["api.example:443"] = {type = "Bearer", token = "x"},  -- capital B
+    },
+  })
+  assertf(not ok, "strict mode should reject unknown rule type")
+  assertf(tostring(err):lower():find("bearer", 1, true) or
+          tostring(err):lower():find("type", 1, true),
+          "strict error should mention the offending type: %s", tostring(err))
+end
+
+-- Strict mode: bearer rule missing `token` is rejected.
+do
+  local ok, err = pcall(proxy.new, {
+    log_level = "quiet",
+    strict = true,
+    allowed_hosts = {["api.example:443"] = {type = "bearer"}},
+  })
+  assertf(not ok, "strict mode should reject bearer without token")
+  assertf(tostring(err):lower():find("token", 1, true),
+          "strict error should mention missing token: %s", tostring(err))
+end
+
+-- Strict mode: basic rule missing username or password is rejected.
+do
+  local ok, err = pcall(proxy.new, {
+    log_level = "quiet",
+    strict = true,
+    allowed_hosts = {
+      ["api.example:443"] = {type = "basic", username = "u"},  -- no password
+    },
+  })
+  assertf(not ok, "strict mode should reject basic without password")
+  assertf(tostring(err):lower():find("password", 1, true),
+          "strict error should mention missing password: %s", tostring(err))
+end
+
+-- Strict mode: header rule missing header_name/header_value is rejected.
+do
+  local ok, err = pcall(proxy.new, {
+    log_level = "quiet",
+    strict = true,
+    allowed_hosts = {
+      ["api.example:443"] = {type = "header", header_name = "x-api-key"},
+    },
+  })
+  assertf(not ok, "strict mode should reject header without header_value")
+  assertf(tostring(err):lower():find("header_value", 1, true),
+          "strict error should mention missing header_value: %s", tostring(err))
+end
+
+-- Strict mode: valid rules still pass.
+do
+  local p = proxy.new{
+    log_level = "quiet",
+    strict = true,
+    allowed_hosts = {
+      ["api.example:443"]     = {type = "bearer", token = "x"},
+      ["basic.example:443"]   = {type = "basic", username = "u", password = "p"},
+      ["header.example:443"]  = {type = "header", header_name = "x-k",
+                                 header_value = "v"},
+      ["pass.example"]        = true,        -- allowed, no auth
+      ["bare.example"]        = {},          -- allowed, no auth
+      ["*.wild.example:443"]  = {type = "bearer", token = "y"},
+    },
+  }
+  assertf(type(p) == "table", "strict + valid rules should construct cleanly")
+end
+
 print("cosmo.sandbox.proxy unit tests passed")

--- a/tool/lua/cosmo/sandbox/test_proxy.lua
+++ b/tool/lua/cosmo/sandbox/test_proxy.lua
@@ -232,91 +232,72 @@ do
   assertf(p._index, "index not built")
 end
 
--- Strict mode: default (strict=false) silently tolerates typos so we
--- don't break existing callers.
-do
-  local ok, p = pcall(proxy.new, {
-    log_level = "quiet",
-    allowed_hosts = {
-      ["api.example:443"] = {type = "Bearer", token = "x"},  -- typo
-    },
-  })
-  assertf(ok, "non-strict mode should accept unknown rule types: %s",
-          tostring(p))
-  assertf(type(p) == "table", "non-strict should still return proxy")
-end
-
--- Strict mode: unknown rule.type is rejected at construction time.
+-- new() rejects unknown rule.type. A typo like "Bearer" (capital B)
+-- must not silently become a pass-through entry that strips auth
+-- from the upstream request.
 do
   local ok, err = pcall(proxy.new, {
     log_level = "quiet",
-    strict = true,
-    allowed_hosts = {
-      ["api.example:443"] = {type = "Bearer", token = "x"},  -- capital B
-    },
+    allowed_hosts = {["api.example:443"] = {type = "Bearer", token = "x"}},
   })
-  assertf(not ok, "strict mode should reject unknown rule type")
+  assertf(not ok, "unknown rule type should raise")
   assertf(tostring(err):lower():find("bearer", 1, true) or
           tostring(err):lower():find("type", 1, true),
-          "strict error should mention the offending type: %s", tostring(err))
+          "error should mention the offending type: %s", tostring(err))
 end
 
--- Strict mode: bearer rule missing `token` is rejected.
+-- bearer rule missing `token` is rejected.
 do
   local ok, err = pcall(proxy.new, {
     log_level = "quiet",
-    strict = true,
     allowed_hosts = {["api.example:443"] = {type = "bearer"}},
   })
-  assertf(not ok, "strict mode should reject bearer without token")
+  assertf(not ok, "bearer without token should raise")
   assertf(tostring(err):lower():find("token", 1, true),
-          "strict error should mention missing token: %s", tostring(err))
+          "error should mention missing token: %s", tostring(err))
 end
 
--- Strict mode: basic rule missing username or password is rejected.
+-- basic rule missing password is rejected.
 do
   local ok, err = pcall(proxy.new, {
     log_level = "quiet",
-    strict = true,
     allowed_hosts = {
-      ["api.example:443"] = {type = "basic", username = "u"},  -- no password
+      ["api.example:443"] = {type = "basic", username = "u"},
     },
   })
-  assertf(not ok, "strict mode should reject basic without password")
+  assertf(not ok, "basic without password should raise")
   assertf(tostring(err):lower():find("password", 1, true),
-          "strict error should mention missing password: %s", tostring(err))
+          "error should mention missing password: %s", tostring(err))
 end
 
--- Strict mode: header rule missing header_name/header_value is rejected.
+-- header rule missing header_value is rejected.
 do
   local ok, err = pcall(proxy.new, {
     log_level = "quiet",
-    strict = true,
     allowed_hosts = {
       ["api.example:443"] = {type = "header", header_name = "x-api-key"},
     },
   })
-  assertf(not ok, "strict mode should reject header without header_value")
+  assertf(not ok, "header without header_value should raise")
   assertf(tostring(err):lower():find("header_value", 1, true),
-          "strict error should mention missing header_value: %s", tostring(err))
+          "error should mention missing header_value: %s", tostring(err))
 end
 
--- Strict mode: valid rules still pass.
+-- Valid rules — including bare-true and empty-table pass-through — construct.
 do
   local p = proxy.new{
     log_level = "quiet",
-    strict = true,
     allowed_hosts = {
-      ["api.example:443"]     = {type = "bearer", token = "x"},
-      ["basic.example:443"]   = {type = "basic", username = "u", password = "p"},
-      ["header.example:443"]  = {type = "header", header_name = "x-k",
-                                 header_value = "v"},
-      ["pass.example"]        = true,        -- allowed, no auth
-      ["bare.example"]        = {},          -- allowed, no auth
-      ["*.wild.example:443"]  = {type = "bearer", token = "y"},
+      ["api.example:443"]    = {type = "bearer", token = "x"},
+      ["basic.example:443"]  = {type = "basic", username = "u", password = "p"},
+      ["header.example:443"] = {type = "header", header_name = "x-k",
+                                header_value = "v"},
+      ["pass.example"]       = true,        -- allowed, no auth
+      ["bare.example"]       = {},          -- allowed, no auth
+      ["*.wild.example:443"] = {type = "bearer", token = "y"},
     },
   }
-  assertf(type(p) == "table", "strict + valid rules should construct cleanly")
+  assertf(type(p) == "table", "valid rules should construct cleanly")
 end
 
 print("cosmo.sandbox.proxy unit tests passed")


### PR DESCRIPTION
Off by default. When `opts.strict = true` is passed to proxy.new or proxy.start, every allowed_hosts rule is validated at construction: unknown rule `type` values (e.g. "Bearer" typo'd for "bearer") and missing required fields (bearer without token, basic without password, header without header_value) raise immediately instead of silently becoming pass-through entries.

Closes #102.