### PR TITLE
sandbox: set __name on Proxy, Handle, and Barrier metatables

### DIFF
--- a/tool/lua/cosmo/sandbox/proc.lua
+++ b/tool/lua/cosmo/sandbox/proc.lua
@@ -99,23 +99,26 @@ end
 --- reads one byte from the read end (EOF counts as signaled, which
 --- propagates child crashes) and closes the read end. `drop_read()`
 --- / `drop_write()` are idempotent.
+local Barrier = {__name = "cosmo.sandbox.proc.Barrier"}
+Barrier.__index = Barrier
+
+function Barrier:signal()
+  if self._w then unix.write(self._w, "x"); unix.close(self._w); self._w = nil end
+end
+function Barrier:wait()
+  if self._r then unix.read(self._r, 1); unix.close(self._r); self._r = nil end
+end
+function Barrier:drop_read()
+  if self._r then unix.close(self._r); self._r = nil end
+end
+function Barrier:drop_write()
+  if self._w then unix.close(self._w); self._w = nil end
+end
+
 function M.barrier()
   local r, w, err = unix.pipe()
   if not r then return nil, w or err end
-  local b = {_r = r, _w = w}
-  function b:signal()
-    if self._w then unix.write(self._w, "x"); unix.close(self._w); self._w = nil end
-  end
-  function b:wait()
-    if self._r then unix.read(self._r, 1); unix.close(self._r); self._r = nil end
-  end
-  function b:drop_read()
-    if self._r then unix.close(self._r); self._r = nil end
-  end
-  function b:drop_write()
-    if self._w then unix.close(self._w); self._w = nil end
-  end
-  return b
+  return setmetatable({_r = r, _w = w}, Barrier)
 end
 
 --- Default signal set forwarded by become_init.

--- a/tool/lua/cosmo/sandbox/proxy.lua
+++ b/tool/lua/cosmo/sandbox/proxy.lua
@@ -684,7 +684,7 @@ end
 --- would strip auth from an otherwise-authenticated egress path.
 --- Unknown *non-type* fields are ignored (forward compatibility).
 
-local Proxy = {}
+local Proxy = {__name = "cosmo.sandbox.proxy.Proxy"}
 Proxy.__index = Proxy
 
 --- Create a new proxy. `opts` fields:
@@ -795,6 +795,16 @@ end
 --------------------------------------------------------------------------------
 -- Convenience: fork + listen + serve in one call.
 
+local Handle = {__name = "cosmo.sandbox.proxy.Handle"}
+Handle.__index = Handle
+
+function Handle:stop()
+  pcall(unix.kill, self.pid, unix.SIGTERM)
+  pcall(unix.wait, self.pid)
+end
+
+M._Handle = Handle
+
 --- proxy.start(opts) → {pid, port, stop()} | nil, unix.Errno
 ---
 --- Fork a child process, bring the proxy up in it, and return a
@@ -851,12 +861,7 @@ function M.start(opts)
     pcall(unix.wait, pid)
     return nil, unix.EIO
   end
-  local handle = {pid = pid, port = port}
-  function handle:stop()
-    pcall(unix.kill, self.pid, unix.SIGTERM)
-    pcall(unix.wait, self.pid)
-  end
-  return handle
+  return setmetatable({pid = pid, port = port}, Handle)
 end
 
 return M

--- a/tool/lua/cosmo/sandbox/test.lua
+++ b/tool/lua/cosmo/sandbox/test.lua
@@ -238,6 +238,12 @@ do
   local b = assert(proc.barrier())
   b:drop_read(); b:drop_read()
   b:drop_write(); b:drop_write()
+  -- The barrier carries a named metatable so runtime type errors
+  -- and tostring() output are discriminable.
+  local bmt = getmetatable(b)
+  assertf(type(bmt) == "table", "barrier should have a metatable")
+  assertf(bmt.__name == "cosmo.sandbox.proc.Barrier",
+          "barrier __name = %s", tostring(bmt.__name))
 end
 
 --------------------------------------------------------------------------------

--- a/tool/lua/cosmo/sandbox/test_proxy.lua
+++ b/tool/lua/cosmo/sandbox/test_proxy.lua
@@ -300,4 +300,26 @@ do
   assertf(type(p) == "table", "valid rules should construct cleanly")
 end
 
+-- Proxy instances carry a named metatable so runtime errors and
+-- tostring() have a type discriminator.
+do
+  local p = proxy.new{log_level = "quiet"}
+  local mt = getmetatable(p)
+  assertf(type(mt) == "table", "proxy.new should return a table with a metatable")
+  assertf(mt.__name == "cosmo.sandbox.proxy.Proxy",
+          "Proxy __name = %s", tostring(mt.__name))
+end
+
+-- The handle returned by proxy.start() also carries a named
+-- metatable. The Handle metatable is exported for testability so we
+-- don't have to fork to verify it here.
+do
+  local Handle = proxy._Handle
+  assertf(type(Handle) == "table", "proxy._Handle should be exported")
+  assertf(Handle.__name == "cosmo.sandbox.proxy.Handle",
+          "Handle __name = %s", tostring(Handle.__name))
+  assertf(type(Handle.stop) == "function",
+          "Handle:stop should live on the metatable")
+end
+
 print("cosmo.sandbox.proxy unit tests passed")


### PR DESCRIPTION
Closes #107.

Gives these objects a runtime type discriminator:
  - tostring() now prints "cosmo.sandbox.proxy.Proxy: 0x..."
    instead of "table: 0x...", likewise for Handle and Barrier.
  - getmetatable(x).__name is usable for provenance guards in
    higher-level callers (e.g. assert_is_handle(proxy_handle)).

The proxy Handle previously had no metatable; move :stop() onto
Handle and export Handle as proxy._Handle so unit tests can
verify the metatable without forking. Same treatment for the
barrier: Barrier now owns the signal/wait/drop_read/drop_write
methods.