### PR TITLE
sandbox: add pledge / unveil to capabilities() probe

### DIFF
--- a/tool/lua/cosmo/sandbox/init.lua
+++ b/tool/lua/cosmo/sandbox/init.lua
@@ -46,9 +46,22 @@ local M = {
 ---   cap_net_admin  geteuid() == 0 (veth pair creation needs root or
 ---                  a network-namespace that owns its own netlink)
 ---   landlock       kernel advertises landlock ABI >= 1 (Linux ≥ 5.13)
+---   pledge         unix.pledge is exported and does not ENOSYS on a
+---                  no-op call (true on Linux via seccomp and on
+---                  OpenBSD via the native syscall)
+---   unveil         unix.unveil is exported and does not ENOSYS on a
+---                  no-op call (true on OpenBSD, and on Linux when
+---                  Landlock-backed unveil is available)
 ---
 --- Higher-level helpers use these to fail fast with a specific reason
 --- rather than bail out on ENOSYS partway through a setup sequence.
+local function probe_nop(fn)
+  if not fn then return false end
+  local ok, err = fn(nil, nil)
+  if ok then return true end
+  if err and err.errno and err:errno() == unix.ENOSYS then return false end
+  return true
+end
 local _caps
 function M.capabilities()
   if _caps then return _caps end
@@ -68,6 +81,8 @@ function M.capabilities()
     pivot_root    = is_linux and unix.pivot_root    ~= nil,
     cap_net_admin = is_linux and unix.geteuid and unix.geteuid() == 0,
     landlock      = ll_ok,
+    pledge        = probe_nop(unix.pledge),
+    unveil        = probe_nop(unix.unveil),
   }
   return _caps
 end

--- a/tool/lua/cosmo/sandbox/test.lua
+++ b/tool/lua/cosmo/sandbox/test.lua
@@ -31,11 +31,39 @@ do
   assertf(type(c) == "table", "capabilities() did not return table")
   for _, k in ipairs{"linux", "user_ns", "mount_ns", "net_ns",
                      "uts_ns", "pid_ns", "pivot_root",
-                     "cap_net_admin", "landlock"} do
+                     "cap_net_admin", "landlock",
+                     "pledge", "unveil"} do
     assertf(type(c[k]) == "boolean",
             "capabilities().%s = %s (expected boolean)", k, tostring(c[k]))
   end
   assertf(c.linux == IS_LINUX, "capabilities().linux mismatch")
+  -- pledge / unveil reflect whether the primitive is both exported and
+  -- callable on the host. On a Linux host with unix.pledge exported,
+  -- the capability must report true (cosmopolitan implements pledge
+  -- via seccomp). If unix.pledge is missing, it must report false.
+  if IS_LINUX then
+    assertf(c.pledge == (unix.pledge ~= nil),
+            "capabilities().pledge = %s, expected %s (unix.pledge=%s)",
+            tostring(c.pledge), tostring(unix.pledge ~= nil),
+            tostring(unix.pledge))
+  end
+  -- unveil capability must match a live probe: if unix.unveil(nil, nil)
+  -- does not return ENOSYS, the primitive is usable and should report
+  -- true; otherwise false.
+  do
+    local want = false
+    if unix.unveil then
+      local ok, err = unix.unveil(nil, nil)
+      if ok then
+        want = true
+      elseif err and err:errno() ~= unix.ENOSYS then
+        want = true
+      end
+    end
+    assertf(c.unveil == want,
+            "capabilities().unveil = %s, expected %s",
+            tostring(c.unveil), tostring(want))
+  end
   -- Result is cached — second call returns the same table.
   assertf(sandbox.capabilities() == c, "capabilities() not cached")
 end


### PR DESCRIPTION
Closes #100. Extends cosmo.sandbox.capabilities() with two new boolean
fields so downstream consumers don't have to reinvent the ENOSYS probe
idiom for these OS-specific primitives:

  pledge  true when unix.pledge is exported and a no-op call does not
          ENOSYS (Linux via seccomp, OpenBSD via native syscall)
  unveil  true when unix.unveil is exported and a no-op call does not
          ENOSYS (OpenBSD native, Linux when Landlock-backed)

The probe calls fn(nil, nil), which is harmless across platforms: it
returns success or ENOSYS without committing to any restriction.

https://claude.ai/code/session_01CBjAf2jE4ruKrxSJvd7vuX