### PR TITLE
sandbox.proxy: add handle:alive() non-blocking health check

### DIFF
--- a/tool/lua/cosmo/sandbox/proxy.lua
+++ b/tool/lua/cosmo/sandbox/proxy.lua
@@ -806,6 +806,26 @@ function Handle:stop()
   pcall(unix.wait, self.pid)
 end
 
+--- handle:alive() → boolean
+---
+--- Non-blocking health check: true while the proxy child is still
+--- running, false once it has exited. Uses waitpid(WNOHANG) so it
+--- returns immediately whether or not the child is ready.
+---
+--- Once alive() has observed an exit, it reaps the child (consuming
+--- the zombie) and clears self.pid to 0. Subsequent calls short-
+--- circuit to false without a waitpid syscall — avoiding races
+--- against pid reuse.
+function Handle:alive()
+  if self.pid == 0 then return false end
+  local gone = unix.wait(self.pid, unix.WNOHANG)
+  if gone == self.pid then
+    self.pid = 0
+    return false
+  end
+  return true
+end
+
 M._Handle = Handle
 
 --- proxy.start(opts) → {pid, port, stop()} | nil, unix.Errno
@@ -813,10 +833,11 @@ M._Handle = Handle
 --- Fork a child process, bring the proxy up in it, and return a
 --- handle the caller can use to address the listening proxy:
 ---
----   p.pid     child pid (for waitpid / signal forwarding)
----   p.port    the port the proxy is listening on (resolved even if
----             opts.bind_port was 0)
----   p:stop()  send SIGTERM and waitpid(p.pid)
+---   p.pid      child pid (for waitpid / signal forwarding)
+---   p.port     the port the proxy is listening on (resolved even if
+---              opts.bind_port was 0)
+---   p:stop()   send SIGTERM and waitpid(p.pid)
+---   p:alive()  non-blocking health check (true while running)
 ---
 --- The parent blocks until the child has bound-and-listened, so
 --- p.port is valid immediately. The port is communicated back via a

--- a/tool/lua/cosmo/sandbox/test_integration.lua
+++ b/tool/lua/cosmo/sandbox/test_integration.lua
@@ -62,6 +62,40 @@ local function in_child(fn)
   end
 end
 
+-- handle:alive() against a real child. This runs unprivileged because
+-- it only needs fork+waitpid — no namespaces. Must come before the
+-- CLONE_NEWNET probe below, which bails out of the whole file on
+-- environments that can't unshare.
+do
+  local Handle = proxy._Handle
+  -- A live, unreaped child: alive() must see it.
+  local rpipe, wpipe = assert(unix.pipe())
+  local pid = assert(unix.fork())
+  if pid == 0 then
+    unix.close(wpipe)
+    -- Block until the parent closes its end, then exit. Using a pipe
+    -- read is race-free: no sleep, no signal choreography.
+    unix.read(rpipe, 1)
+    unix.exit(0)
+  end
+  unix.close(rpipe)
+  local h = setmetatable({pid = pid}, Handle)
+  assertf(h:alive() == true, "alive() on running child should be true")
+  assertf(h.pid == pid, "alive() must not mutate pid while child lives")
+  -- Release the child; poll alive() until it sees the exit.
+  unix.close(wpipe)
+  local deadline = 200  -- 200 * 10ms = 2s budget
+  while deadline > 0 and h:alive() do
+    unix.nanosleep(0, 10 * 1000 * 1000)
+    deadline = deadline - 1
+  end
+  assertf(h:alive() == false,
+          "alive() should return false after child exits")
+  assertf(h.pid == 0,
+          "alive() should clear pid to 0 once the child has been reaped")
+  log("ok: handle:alive() tracks child liveness and reaps on exit")
+end
+
 -- Probe: can we actually unshare(CLONE_NEWNET)? Some kernels disable
 -- unprivileged user-namespace creation, and many environments aren't
 -- root. Rather than fail the test, skip.

--- a/tool/lua/cosmo/sandbox/test_proxy.lua
+++ b/tool/lua/cosmo/sandbox/test_proxy.lua
@@ -320,6 +320,20 @@ do
           "Handle __name = %s", tostring(Handle.__name))
   assertf(type(Handle.stop) == "function",
           "Handle:stop should live on the metatable")
+  assertf(type(Handle.alive) == "function",
+          "Handle:alive should live on the metatable")
+end
+
+-- handle:alive() returns false for a cleared handle (pid == 0). This
+-- is the "already reaped" state that stop() leaves the handle in, so
+-- alive() must short-circuit without invoking waitpid on pid 0 (which
+-- would otherwise race against pid reuse).
+do
+  local Handle = proxy._Handle
+  local h = setmetatable({pid = 0}, Handle)
+  assertf(h:alive() == false, "alive() on pid=0 should be false")
+  -- Second call must remain false and still not crash.
+  assertf(h:alive() == false, "alive() must be idempotent on pid=0")
 end
 
 -- A raising on_log sink must not abort the caller. emit() runs inside


### PR DESCRIPTION
Closes #106. Supervisor code running alongside proxy.start() needs a
cheap way to ask "is the child still running?" without waiting on
SIGCHLD.

handle:alive() uses waitpid(WNOHANG): returns true while the child
runs, false once it exits. On observing an exit it reaps the zombie
and zeros self.pid so subsequent calls short-circuit without another
waitpid syscall — avoiding a race against pid reuse.

Tests cover the pid-already-cleared short-circuit (unit) and the
live-child / exited-child / post-reap lifecycle against a real
forked child (integration).

https://claude.ai/code/session_01HFCAAi9x7yioyQmitfPGDU