### PR TITLE
sandbox.proc: add setup_userns_maps(uid, gid) helper

### DIFF
--- a/tool/lua/cosmo/sandbox/proc.lua
+++ b/tool/lua/cosmo/sandbox/proc.lua
@@ -71,6 +71,47 @@ function M.drop_privs(uid, gid)
   return true
 end
 
+--- proc.setup_userns_maps(uid, gid) → true | nil, unix.Errno
+---
+--- Write uid_map / setgroups / gid_map for the current process so that
+--- inner uid 0 maps to the host `uid` (and inner gid 0 to host `gid`).
+--- Must be called after `unshare(CLONE_NEWUSER)` and before any
+--- operation that requires a valid identity (setresuid, capset, mount,
+--- etc). Equivalent to the canonical three-step incantation:
+---
+---     echo "0 $uid 1" > /proc/self/uid_map
+---     echo "deny"     > /proc/self/setgroups   # kernel ≥ 3.19
+---     echo "0 $gid 1" > /proc/self/gid_map
+---
+--- The setgroups "deny" write must come before the gid_map write on
+--- kernels ≥3.19; an unprivileged writer is rejected from gid_map
+--- otherwise. On kernels old enough not to expose setgroups as a
+--- proc file the write fails with ENOENT, which is benign and
+--- silently ignored.
+---
+--- Arguments default to the current euid/egid, matching the common
+--- "map my host identity to root inside the new user ns" case.
+local function write_all(path, data)
+  local fd, err = unix.open(path, unix.O_WRONLY)
+  if not fd then return nil, err end
+  local ok, werr = unix.write(fd, data)
+  unix.close(fd)
+  if not ok then return nil, werr end
+  return true
+end
+
+function M.setup_userns_maps(uid, gid)
+  uid = uid or unix.geteuid()
+  gid = gid or unix.getegid()
+  local ok, err = write_all("/proc/self/uid_map", "0 "..uid.." 1\n")
+  if not ok then return nil, err end
+  local sg, sgerr = write_all("/proc/self/setgroups", "deny")
+  if not sg and sgerr and sgerr:errno() ~= unix.ENOENT then
+    return nil, sgerr
+  end
+  return write_all("/proc/self/gid_map", "0 "..gid.." 1\n")
+end
+
 --- proc.barrier() → {signal, wait, drop_read, drop_write} | nil, err
 ---
 --- Cross-process synchronization primitive: a one-shot pipe-based

--- a/tool/lua/cosmo/sandbox/test.lua
+++ b/tool/lua/cosmo/sandbox/test.lua
@@ -248,7 +248,8 @@ do
   local proc = require "cosmo.sandbox.proc"
   -- Function-shape sanity.
   for _, fn in ipairs{"no_new_privs", "drop_privs",
-                      "become_init", "barrier"} do
+                      "become_init", "barrier",
+                      "setup_userns_maps"} do
     assertf(type(proc[fn]) == "function", "proc.%s missing", fn)
   end
   -- DEFAULT_SIGNALS is a sane set.

--- a/tool/lua/cosmo/sandbox/test_integration.lua
+++ b/tool/lua/cosmo/sandbox/test_integration.lua
@@ -251,6 +251,67 @@ do
 end
 
 --------------------------------------------------------------------------------
+-- cosmo.sandbox.proc.setup_userns_maps
+--
+-- After unshare(CLONE_NEWUSER), the child is uid=nobody until uid_map /
+-- gid_map are written. setup_userns_maps() writes the canonical
+-- "inner uid 0 → host uid" mapping (with setgroups=deny for kernels
+-- ≥3.19, so the gid_map write is accepted without privilege).
+
+do
+  local proc = require "cosmo.sandbox.proc"
+  local rc = in_child(function()
+    local u_ok, u_err = unix.unshare(unix.CLONE_NEWUSER)
+    if not u_ok then
+      io.stderr:write("unshare(CLONE_NEWUSER): "..tostring(u_err).."\n")
+      unix.exit(42)
+    end
+    local host_uid = unix.getuid()
+    local host_gid = unix.getgid()
+
+    local ok, err = proc.setup_userns_maps()
+    assertf(ok, "setup_userns_maps() failed: %s", tostring(err))
+
+    -- Inside the new user ns, the process should now appear as uid 0.
+    local ruid, euid, suid = unix.getresuid()
+    assertf(ruid == 0 and euid == 0 and suid == 0,
+            "expected uid 0/0/0 inside ns, got %d/%d/%d",
+            ruid, euid, suid)
+
+    -- uid_map must read back as "0 <host_uid> 1".
+    local ufd = assert(unix.open("/proc/self/uid_map", unix.O_RDONLY))
+    local uc  = assert(unix.read(ufd, 4096))
+    unix.close(ufd)
+    local a, b, c = uc:match("(%d+)%s+(%d+)%s+(%d+)")
+    assertf(tonumber(a) == 0 and tonumber(b) == host_uid and tonumber(c) == 1,
+            "uid_map = %q, expected '0 %d 1'", uc, host_uid)
+
+    -- setgroups must have been set to "deny" (kernel ≥3.19).
+    local sgfd = unix.open("/proc/self/setgroups", unix.O_RDONLY)
+    if sgfd then
+      local sg = unix.read(sgfd, 4096) or ""
+      unix.close(sgfd)
+      assertf(sg:match("deny"),
+              "setgroups = %q, expected 'deny'", sg)
+    end
+
+    -- gid_map must read back as "0 <host_gid> 1".
+    local gfd = assert(unix.open("/proc/self/gid_map", unix.O_RDONLY))
+    local gc2 = assert(unix.read(gfd, 4096))
+    unix.close(gfd)
+    local ga, gb, gcc = gc2:match("(%d+)%s+(%d+)%s+(%d+)")
+    assertf(tonumber(ga) == 0 and tonumber(gb) == host_gid and tonumber(gcc) == 1,
+            "gid_map = %q, expected '0 %d 1'", gc2, host_gid)
+  end)
+  if rc == 42 then
+    log("skip: setup_userns_maps (unshare(CLONE_NEWUSER) denied)")
+  else
+    assertf(rc == 0, "setup_userns_maps integration exited %d", rc)
+    log("ok: setup_userns_maps writes uid_map/setgroups/gid_map")
+  end
+end
+
+--------------------------------------------------------------------------------
 -- Proxy integration tests
 --
 -- Topology:


### PR DESCRIPTION
After unshare(CLONE_NEWUSER), callers need to write uid_map /
setgroups / gid_map to get a usable identity. Getting the setgroups
"deny" step wrong (or out of order) fails in confusing ways. Ship
the canonical incantation as a library helper so jail assembly
doesn't re-roll it per consumer.

Closes #104