### PR TITLE
sandbox.proxy: make handle:stop() idempotent with SIGKILL escalation

### DIFF
--- a/tool/lua/cosmo/sandbox/proxy.lua
+++ b/tool/lua/cosmo/sandbox/proxy.lua
@@ -801,9 +801,43 @@ end
 local Handle = {__name = "cosmo.sandbox.proxy.Handle"}
 Handle.__index = Handle
 
-function Handle:stop()
-  pcall(unix.kill, self.pid, unix.SIGTERM)
-  pcall(unix.wait, self.pid)
+local function now_ms()
+  local s, ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  return s * 1000 + ns // 1000000
+end
+
+--- handle:stop([timeout_ms]) → true
+---
+--- Send SIGTERM and reap. Idempotent: once the child has been reaped
+--- (self.pid == 0), subsequent calls short-circuit without re-
+--- signalling — critical because `kill(0, ...)` targets the caller's
+--- whole process group, and a reused pid would receive a spurious
+--- signal. Escalates to SIGKILL if the child hasn't exited within
+--- `timeout_ms` (default 5000), so a hung or SIGTERM-ignoring worker
+--- can't wedge the supervisor forever.
+---
+--- Always returns true; signal/wait failures are swallowed via pcall
+--- since the post-condition (pid cleared, child no longer our
+--- responsibility) is reached regardless.
+function Handle:stop(timeout_ms)
+  if self.pid == 0 then return true end
+  timeout_ms = timeout_ms or 5000
+  local pid = self.pid
+  pcall(unix.kill, pid, unix.SIGTERM)
+  local deadline = now_ms() + timeout_ms
+  while true do
+    local gone = unix.wait(pid, unix.WNOHANG)
+    if gone == pid then
+      self.pid = 0
+      return true
+    end
+    if now_ms() >= deadline then break end
+    unix.nanosleep(0, 10 * 1000 * 1000)
+  end
+  pcall(unix.kill, pid, unix.SIGKILL)
+  pcall(unix.wait, pid)
+  self.pid = 0
+  return true
 end
 
 --- handle:alive() → boolean

--- a/tool/lua/cosmo/sandbox/test_integration.lua
+++ b/tool/lua/cosmo/sandbox/test_integration.lua
@@ -96,6 +96,64 @@ do
   log("ok: handle:alive() tracks child liveness and reaps on exit")
 end
 
+-- handle:stop() against a cooperative child: the child blocks on a
+-- pipe read, and SIGTERM's default action is Terminate, so stop()
+-- should reap it cleanly, clear self.pid to 0, and return true. A
+-- second stop() must be a no-op — no signal, no wait — because the
+-- pid may have been recycled by the kernel.
+do
+  local Handle = proxy._Handle
+  local rpipe, wpipe = assert(unix.pipe())
+  local pid = assert(unix.fork())
+  if pid == 0 then
+    unix.close(wpipe)
+    -- Block until the write end closes (never, in this test) or a
+    -- signal terminates us. SIGTERM has default-action Terminate.
+    unix.read(rpipe, 1)
+    unix.exit(0)
+  end
+  unix.close(rpipe); unix.close(wpipe)
+  local h = setmetatable({pid = pid}, Handle)
+  assertf(h:stop() == true, "stop() should return true on cooperative child")
+  assertf(h.pid == 0, "stop() must clear pid to 0 after reap")
+  -- Idempotent: a second stop() must not re-signal, must still return true.
+  assertf(h:stop() == true, "second stop() should be a no-op returning true")
+  assertf(h.pid == 0, "pid must remain 0 after second stop()")
+  log("ok: handle:stop() reaps cooperative child and is idempotent")
+end
+
+-- handle:stop() against a SIGTERM-ignoring child: after the timeout
+-- elapses, stop() must escalate to SIGKILL and reap the child. The
+-- bounded timeout prevents a hostile or stuck worker from wedging the
+-- supervisor forever.
+do
+  local Handle = proxy._Handle
+  local rpipe, wpipe = assert(unix.pipe())
+  local pid = assert(unix.fork())
+  if pid == 0 then
+    unix.close(wpipe)
+    -- Ignore SIGTERM so only SIGKILL can terminate us. A stray
+    -- SIGTERM still interrupts the read() syscall (EINTR), so loop.
+    unix.sigaction(unix.SIGTERM, unix.SIG_IGN)
+    while true do unix.read(rpipe, 1) end
+    unix.exit(0)
+  end
+  unix.close(rpipe); unix.close(wpipe)
+  local h = setmetatable({pid = pid}, Handle)
+  -- Short timeout so the test runs quickly. 200ms is well over the
+  -- 10ms polling granularity but still short compared to a real user
+  -- pressing Ctrl-C.
+  local t0 = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  assertf(h:stop(200) == true, "stop(200) should still return true")
+  local t1 = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  assertf(h.pid == 0, "pid must be cleared after SIGKILL escalation")
+  -- Sanity: the call took at least the timeout (we had to wait) but
+  -- not unreasonably long (we didn't wedge).
+  assertf(t1 - t0 < 5,
+          "stop() with 200ms timeout took %d seconds", t1 - t0)
+  log("ok: handle:stop() escalates to SIGKILL after timeout")
+end
+
 -- Probe: can we actually unshare(CLONE_NEWNET)? Some kernels disable
 -- unprivileged user-namespace creation, and many environments aren't
 -- root. Rather than fail the test, skip.

--- a/tool/lua/cosmo/sandbox/test_proxy.lua
+++ b/tool/lua/cosmo/sandbox/test_proxy.lua
@@ -336,6 +336,32 @@ do
   assertf(h:alive() == false, "alive() must be idempotent on pid=0")
 end
 
+-- handle:stop() on a cleared handle (pid == 0) short-circuits: no
+-- signal goes out, no waitpid, and it returns true (idempotent
+-- success). This is critical because sending a signal to a reaped pid
+-- races against pid reuse — a second stop() call must not be able to
+-- target an unrelated process that recycled the pid.
+do
+  local Handle = proxy._Handle
+  local h = setmetatable({pid = 0}, Handle)
+  assertf(h:stop() == true, "stop() on pid=0 should return true")
+  assertf(h.pid == 0, "stop() on pid=0 must leave pid cleared")
+  -- Second call must also return true and remain a no-op.
+  assertf(h:stop() == true, "stop() must be idempotent on pid=0")
+  assertf(h.pid == 0, "stop() on pid=0 must not mutate pid")
+end
+
+-- stop() accepts an optional timeout_ms argument so callers can bound
+-- how long to wait before escalating a stuck child to SIGKILL. Passing
+-- it on a cleared handle is still a no-op — the timeout only matters
+-- when there is actually a live child to reap.
+do
+  local Handle = proxy._Handle
+  local h = setmetatable({pid = 0}, Handle)
+  assertf(h:stop(1000) == true,
+          "stop(timeout_ms) on pid=0 should return true")
+end
+
 -- A raising on_log sink must not abort the caller. emit() runs inside
 -- the per-connection worker; if a bad user sink propagates an error,
 -- the handler dies mid-request. Guard it with pcall.


### PR DESCRIPTION
The old stop() sent SIGTERM and called wait() unconditionally. Two bugs:

  1. Not idempotent. After the child had been reaped, a second stop() would send SIGTERM to pid=self.pid, but if the handle had been left at the default pid=0 (e.g. after alive() observed an exit) that's kill(0, SIGTERM) — "signal every process in the caller's process group" — killing the supervisor itself.

  2. No timeout. wait() without WNOHANG blocks forever, so a child ignoring SIGTERM (or stuck in uninterruptible I/O) wedges the caller.

Fix both: short-circuit on pid==0, poll waitpid(WNOHANG) against a monotonic deadline, and escalate to SIGKILL if the child hasn't exited within timeout_ms (default 5000). Always returns true; pid is cleared regardless so subsequent calls are safe.

Closes whilp/cosmopolitan#101