### PR TITLE
sandbox.proxy: add resolve_timeout_ms to bound per-dial DNS resolution

### DIFF
--- a/tool/lua/cosmo/sandbox/proxy.lua
+++ b/tool/lua/cosmo/sandbox/proxy.lua
@@ -27,7 +27,7 @@
 local unix = require "unix"
 local cosmo = require "cosmo"
 
-local M = {_VERSION = "0.0.2"}
+local M = {_VERSION = "0.0.3"}
 
 --------------------------------------------------------------------------------
 -- Logging
@@ -307,21 +307,76 @@ M._pump = pump
 --
 -- cosmo.ParseIp returns -1 (not nil) when the string isn't a literal
 -- IP, so we explicitly fall back to ResolveIp on -1.
-local function resolve_v4(host)
+--
+-- When `timeout_ms` is non-nil, DNS resolution is bounded: the actual
+-- lookup runs in a forked helper and the parent polls the result pipe
+-- with ppoll(timeout_ms). If the deadline elapses the helper is
+-- SIGKILL'd and (nil, "resolve timeout") is returned, so a hostile or
+-- tarpitting upstream resolver can't wedge a per-connection worker
+-- past the configured budget. Literal IPs skip the fork entirely.
+--
+-- `resolver` is an injection seam for tests: it defaults to
+-- cosmo.ResolveIp and takes `(host)` → ip | nil, err. Passing a fake
+-- slow/failing resolver lets the timeout path be exercised without a
+-- working DNS stack.
+local function resolve_v4(host, timeout_ms, resolver)
   local ip = cosmo.ParseIp(host)
   if ip and ip ~= -1 then return ip end
-  return cosmo.ResolveIp(host)
+  resolver = resolver or cosmo.ResolveIp
+  if not timeout_ms then
+    return resolver(host)
+  end
+  local r, w, perr = unix.pipe()
+  if not r then return nil, w or perr end
+  local pid, ferr = unix.fork()
+  if not pid then
+    unix.close(r); unix.close(w)
+    return nil, ferr
+  end
+  if pid == 0 then
+    unix.close(r)
+    local resolved, rerr = resolver(host)
+    if resolved then
+      unix.write(w, "O" .. string.pack("<i8", resolved))
+    else
+      unix.write(w, "E" .. tostring(rerr or "resolve failed"))
+    end
+    unix.close(w)
+    unix.exit(0)
+  end
+  unix.close(w)
+  local ready = unix.poll({[r] = unix.POLLIN}, timeout_ms)
+  if not ready or not ready[r] then
+    pcall(unix.kill, pid, unix.SIGKILL)
+    pcall(unix.wait, pid)
+    unix.close(r)
+    return nil, "resolve timeout"
+  end
+  -- Drain the pipe. The helper writes at most 9 bytes (1 status byte +
+  -- 8-byte packed int) on success, or "E" + a short error string.
+  local data = unix.read(r, 4096) or ""
+  unix.close(r)
+  pcall(unix.wait, pid)
+  local tag = data:sub(1, 1)
+  if tag == "O" and #data >= 9 then
+    return string.unpack("<i8", data, 2)
+  elseif tag == "E" then
+    return nil, data:sub(2)
+  end
+  return nil, "resolve failed"
 end
+M._resolve_v4 = resolve_v4
 
 -- Open a TCP connection to (host, port) in the namespace identified by
 -- `upstream_ns_fd`, falling back to the current namespace if the fd is
--- nil. Returns fd | nil,err.
-local function dial(host, port, upstream_ns_fd)
+-- nil. `resolve_timeout_ms` (optional) bounds DNS resolution per dial.
+-- Returns fd | nil,err.
+local function dial(host, port, upstream_ns_fd, resolve_timeout_ms)
   if upstream_ns_fd then
     local ok, err = unix.setns(upstream_ns_fd, unix.CLONE_NEWNET)
     if not ok then return nil, err end
   end
-  local ip, rerr = resolve_v4(host)
+  local ip, rerr = resolve_v4(host, resolve_timeout_ms)
   if not ip then return nil, rerr end
   local sk, serr = unix.socket(unix.AF_INET, unix.SOCK_STREAM, 0)
   if not sk then return nil, serr end
@@ -533,7 +588,8 @@ local function handle(self, client_fd)
       return
     end
     logger.debug("dial", {method = "CONNECT", host = host, port = port})
-    local up, derr = dial(host, port, self._upstream_ns_fd)
+    local up, derr = dial(host, port, self._upstream_ns_fd,
+                          self._resolve_timeout_ms)
     if not up then
       logger.warn("upstream_fail",
                   {method = "CONNECT", host = host, port = port, err = derr})
@@ -702,6 +758,13 @@ Proxy.__index = Proxy
 ---   log_format       "text"|"json"           (default "text")
 ---   log_file         path                    (default stderr)
 ---   accept_backlog   int                     (default 32)
+---   resolve_timeout_ms int | false            (default 5000)
+---                    Per-dial DNS resolution deadline in milliseconds.
+---                    A hostile or slow upstream resolver is capped at
+---                    this budget; on timeout the dial fails with
+---                    "resolve timeout" and the connection gets 502.
+---                    Pass `false` to opt out of the timeout entirely
+---                    (restores pre-v0.0.3 unbounded behaviour).
 ---
 --- Raises if any allowed_hosts rule has an unknown `type` or is
 --- missing a required field — see "Allowlist rule schema" above.
@@ -715,6 +778,14 @@ function M.new(opts)
   end
   local logger, lerr = make_logger(opts)
   if not logger then error(lerr) end
+  -- `resolve_timeout_ms = false` opts out of the timeout; a nil key
+  -- falls back to the 5000ms default.
+  local resolve_timeout_ms
+  if opts.resolve_timeout_ms == nil then
+    resolve_timeout_ms = 5000
+  elseif opts.resolve_timeout_ms then
+    resolve_timeout_ms = opts.resolve_timeout_ms
+  end
   return setmetatable({
     _bind_ip = opts.bind_ip or cosmo.ParseIp("127.0.0.1"),
     _bind_port = opts.bind_port or 3128,
@@ -722,6 +793,7 @@ function M.new(opts)
     _upstream_ns_fd = opts.upstream_ns_fd,
     _logger = logger,
     _backlog = opts.accept_backlog or 32,
+    _resolve_timeout_ms = resolve_timeout_ms,
     _listen_fd = nil,
   }, Proxy)
 end

--- a/tool/lua/cosmo/sandbox/test_proxy.lua
+++ b/tool/lua/cosmo/sandbox/test_proxy.lua
@@ -368,4 +368,87 @@ do
           "sink received wrong fields")
 end
 
+--------------------------------------------------------------------------------
+-- resolve_v4: optional timeout_ms bounds DNS resolution per dial.
+
+local unix = require "unix"
+
+-- Literal IPv4 addresses are parsed inline — no DNS, no fork, and
+-- timeout_ms is irrelevant (even a 1ms ceiling must succeed).
+do
+  assertf(type(proxy._resolve_v4) == "function",
+          "_resolve_v4 should be exported")
+  local want = cosmo.ParseIp("127.0.0.1")
+  local ip = assert(proxy._resolve_v4("127.0.0.1"))
+  assertf(ip == want, "no-timeout literal IP wrong: %s", tostring(ip))
+  ip = assert(proxy._resolve_v4("127.0.0.1", 1))
+  assertf(ip == want, "1ms literal IP wrong: %s", tostring(ip))
+end
+
+-- With a timeout, a fast custom resolver returns its result verbatim.
+-- The resolver seam (3rd-positional parameter) is used so the test
+-- doesn't depend on a working DNS stack. Note the resolver runs in a
+-- forked child, so we observe the outcome via the returned value, not
+-- via shared Lua state.
+do
+  local fake = function(host)
+    assertf(host == "example.test", "resolver got wrong host: %s", host)
+    return 0x01020304
+  end
+  local ip = assert(proxy._resolve_v4("example.test", 500, fake))
+  assertf(ip == 0x01020304, "fast resolver result wrong: %s", tostring(ip))
+end
+
+-- A resolver that blocks past the deadline must be bounded: the call
+-- returns nil + an error that mentions the timeout, in under ~1 second
+-- of wall-clock. This is the whole point of the option — without it,
+-- a hostile/slow upstream DNS could wedge a worker indefinitely.
+do
+  local slow = function()
+    -- Sleep 3 seconds; the parent should kill us well before this
+    -- returns.
+    unix.nanosleep(3, 0)
+    return 0x0a0b0c0d
+  end
+  local t0_s, t0_ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  local ip, err = proxy._resolve_v4("slow.test", 100, slow)
+  local t1_s, t1_ns = unix.clock_gettime(unix.CLOCK_MONOTONIC)
+  local elapsed_ms = (t1_s - t0_s) * 1000 + (t1_ns - t0_ns) / 1e6
+  assertf(ip == nil, "slow resolver should not return an IP")
+  assertf(err and tostring(err):lower():find("timeout", 1, true),
+          "error should mention timeout, got: %s", tostring(err))
+  assertf(elapsed_ms < 1500,
+          "timeout took %.0fms — should be ~100ms, well under 1.5s",
+          elapsed_ms)
+end
+
+-- A resolver that fails (returns nil, err) propagates the error
+-- through the timeout wrapper instead of dressing it up as a timeout.
+do
+  local failing = function() return nil, "nxdomain-test" end
+  local ip, err = proxy._resolve_v4("nope.test", 500, failing)
+  assertf(ip == nil, "failing resolver should not return an IP")
+  assertf(err and tostring(err):find("nxdomain-test", 1, true),
+          "upstream error should propagate, got: %s", tostring(err))
+end
+
+-- resolve_timeout_ms flows through from opts to the Proxy instance so
+-- handle()/dial() can consult it. Default is 5000ms (per issue #108);
+-- an explicit value overrides the default, and explicit nil disables
+-- the timeout entirely.
+do
+  local p = proxy.new{log_level = "quiet"}
+  assertf(p._resolve_timeout_ms == 5000,
+          "default resolve_timeout_ms should be 5000, got %s",
+          tostring(p._resolve_timeout_ms))
+  p = proxy.new{log_level = "quiet", resolve_timeout_ms = 1234}
+  assertf(p._resolve_timeout_ms == 1234,
+          "explicit resolve_timeout_ms should be honoured, got %s",
+          tostring(p._resolve_timeout_ms))
+  p = proxy.new{log_level = "quiet", resolve_timeout_ms = false}
+  assertf(p._resolve_timeout_ms == nil,
+          "explicit false should disable timeout, got %s",
+          tostring(p._resolve_timeout_ms))
+end
+
 print("cosmo.sandbox.proxy unit tests passed")


### PR DESCRIPTION
A hostile or slow upstream resolver (DNS tarpit) could wedge a per-connection worker indefinitely because resolve_v4() called cosmo.ResolveIp synchronously with no deadline. Under sustained slow-DNS load the fork budget drains: each stuck worker holds a pid and fd until the resolver gives up on its own schedule.

Run the lookup in a forked helper and bound the parent's wait with unix.poll(timeout_ms). On deadline the helper is SIGKILL'd and (nil, "resolve timeout") is returned, surfacing as 502 Bad Gateway with a specific logged reason. Literal IPs skip the fork entirely.

Default is 5000ms; pass resolve_timeout_ms=false to opt out.

Closes whilp/cosmopolitan#108.