### PR TITLE
unix: expose sethostname(2) binding (#118)

### DIFF
--- a/libc/calls/sethostname.c
+++ b/libc/calls/sethostname.c
@@ -1,0 +1,54 @@
+/*-*- mode:c;indent-tabs-mode:nil;c-basic-offset:2;tab-width:8;coding:utf-8 -*-│
+│ vi: set et ft=c ts=2 sts=2 sw=2 fenc=utf-8                               :vi │
+╞══════════════════════════════════════════════════════════════════════════════╡
+│ Copyright 2026 Justine Alexandra Roberts Tunney                              │
+│                                                                              │
+│ Permission to use, copy, modify, and/or distribute this software for         │
+│ any purpose with or without fee is hereby granted, provided that the         │
+│ above copyright notice and this permission notice appear in all copies.      │
+│                                                                              │
+│ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL                │
+│ WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED                │
+│ WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE             │
+│ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL         │
+│ DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR        │
+│ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER               │
+│ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR             │
+│ PERFORMANCE OF THIS SOFTWARE.                                                │
+╚─────────────────────────────────────────────────────────────────────────────*/
+#include "libc/calls/syscall-sysv.internal.h"
+#include "libc/dce.h"
+#include "libc/intrin/strace.h"
+#include "libc/runtime/runtime.h"
+#include "libc/sysv/errfuns.h"
+
+/**
+ * Sets name of current host.
+ *
+ * The counterpart of gethostname(). Typical use is inside a fresh UTS
+ * namespace created via `unshare(CLONE_NEWUTS)` so that sandboxed
+ * processes see their own hostname without affecting the rest of the
+ * system.
+ *
+ * @param name is the new hostname
+ * @param len is the length of `name` in bytes (not counting a nul
+ *     terminator, which is not required)
+ * @return 0 on success, or -1 w/ errno
+ * @raise EFAULT if `name` is an invalid address
+ * @raise EINVAL if `len` exceeds the implementation limit
+ * @raise EPERM if the caller lacks `CAP_SYS_ADMIN` in the current UTS
+ *     namespace
+ * @raise ENOSYS on Windows
+ */
+int sethostname(const char *name, size_t len) {
+  int rc;
+  if (IsWindows()) {
+    rc = enosys();
+  } else if (!name) {
+    rc = efault();
+  } else {
+    rc = sys_sethostname(name, len);
+  }
+  STRACE("sethostname(%#.*s, %'zu) → %d% m", (int)len, name, len, rc);
+  return rc;
+}

--- a/libc/calls/syscall-sysv.internal.h
+++ b/libc/calls/syscall-sysv.internal.h
@@ -100,6 +100,7 @@ i32 sys_setgid(i32);
 i32 sys_setpgid(i32, i32);
 i32 sys_setpriority(i32, u32, i32);
 i32 sys_setns(i32, i32);
+i32 sys_sethostname(const char *, u64);
 i32 sys_setregid(u32, u32);
 i32 sys_setresgid(u32, u32, u32);
 i32 sys_setresuid(u32, u32, u32);

--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -2139,6 +2139,16 @@ static int LuaUnixGethostname(lua_State *L) {
   return LuaUnixSysretErrno(L, "gethostname", olderr);
 }
 
+// unix.sethostname(name:str)
+//     ├─→ true
+//     └─→ nil, unix.Errno
+static int LuaUnixSethostname(lua_State *L) {
+  size_t len;
+  int olderr = errno;
+  const char *name = luaL_checklstring(L, 1, &len);
+  return SysretBool(L, "sethostname", olderr, sethostname(name, len));
+}
+
 // unix.accept(serverfd:int[, flags:int])
 //     ├─→ clientfd:int, ip:uint32, port:uint16
 //     ├─→ clientfd:int, unixpath:str
@@ -4070,6 +4080,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"geteuid", LuaUnixGeteuid},          // get effective user id of process
     {"getgid", LuaUnixGetgid},            // get real group id of process
     {"gethostname", LuaUnixGethostname},  // get hostname of this machine
+    {"sethostname", LuaUnixSethostname},  // set hostname of this machine
     {"getlogin", LuaUnixGetlogin},        // get login name of current user
     {"getpeername", LuaUnixGetpeername},  // get address of remote end
     {"getpgid", LuaUnixGetpgid},          // get process group id of pid

--- a/tool/lua/cosmo/sandbox/test.lua
+++ b/tool/lua/cosmo/sandbox/test.lua
@@ -81,7 +81,8 @@ assertf(unix.CLONE_NEWCGROUP == 0x02000000, "CLONE_NEWCGROUP wrong")
 for _, name in ipairs{"unshare", "setns", "ioctl", "mount", "unmount",
                       "pivot_root", "prctl", "capget", "capset",
                       "landlock_create_ruleset", "landlock_add_rule",
-                      "landlock_restrict_self"} do
+                      "landlock_restrict_self",
+                      "gethostname", "sethostname"} do
   assertf(type(unix[name]) == "function", "unix.%s missing", name)
 end
 
@@ -195,6 +196,27 @@ do
   assertf(ok == nil, "prctl(-999) should fail")
   assertf(err:errno() == unix.EINVAL,
           "prctl(-999) expected EINVAL, got %s", err:name())
+end
+
+-- sethostname round-trip / error-shape contract. Setting the hostname
+-- requires CAP_SYS_ADMIN in the current UTS namespace, so an unprivileged
+-- test caller must see (nil, unix.Errno) — not a crash, not a nil
+-- function, not a naked integer. If the caller *is* privileged, the
+-- round-trip with the current hostname must succeed.
+if IS_LINUX then
+  local host = assert(unix.gethostname())
+  local ok, err = unix.sethostname(host)
+  if ok then
+    assertf(ok == true, "sethostname(host) expected true, got %s", tostring(ok))
+  else
+    assertf(type(err) == "userdata",
+            "sethostname should return Errno userdata on failure, got %s",
+            type(err))
+    local eno = err:errno()
+    assertf(eno == unix.EPERM or eno == unix.EACCES,
+            "sethostname unprivileged expected EPERM/EACCES, got %s",
+            err:name())
+  end
 end
 
 --------------------------------------------------------------------------------

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -7176,6 +7176,15 @@ function unix.poll(fds, timeoutms) end
 ---@overload fun(): nil, unix.Errno
 function unix.gethostname() end
 
+--- Sets hostname of system.
+---
+--- Requires CAP_SYS_ADMIN on Linux (or root on BSDs); returns `EPERM`
+--- otherwise. Not supported on Windows, where it returns `ENOSYS`.
+---@param name string
+---@return true
+---@overload fun(name:string): nil, unix.Errno
+function unix.sethostname(name) end
+
 --- Begins listening for incoming connections on a socket.
 ---@param fd integer
 ---@param backlog integer?


### PR DESCRIPTION
Adds cosmo.unix.sethostname(name) as the natural counterpart to the existing cosmo.unix.gethostname(). Returns true on success and (nil, unix.Errno) on failure.

Lets UTS-namespace sandbox builders set the hostname via a POSIX syscall instead of falling back to writing /proc/sys/kernel/hostname, which keeps non-Linux hosts reachable from the same code path and surfaces EPERM rather than EACCES when the caller lacks CAP_SYS_ADMIN.

Ships a thin libc wrapper for sethostname() on top of the existing sys_sethostname syscall slot; Windows still returns ENOSYS.

https://claude.ai/code/session_013zPqTquZannmmMo6rbD34Q