### PR TITLE
parsehttpmessage: clamp resume position before capacity check

### DIFF
--- a/net/http/parsehttpmessage.c
+++ b/net/http/parsehttpmessage.c
@@ -316,13 +316,15 @@ int ParseHttpMessage(struct HttpMessage *r, const char *p, size_t n, size_t c) {
         __builtin_unreachable();
     }
   }
-  if (r->i < c) {
-    // Clamp position to not skip past buffer end.
-    // Inner loops may set r->i = n, then outer for loop increments to n+1.
-    // On resume we want to start at position n, not n+1.
-    if (r->i > n)
-      r->i = n;
+  // Clamp position to not skip past buffer end.
+  // Inner loops may set r->i = n, then outer for loop increments to n+1.
+  // On resume we want to start at position n, not n+1. This must happen
+  // before the capacity comparison: otherwise when c == n+1 the overshot
+  // r->i == n+1 fails the `r->i < c` test and we wrongly return ebadmsg()
+  // for a message that is merely incomplete.
+  if (r->i > n)
+    r->i = n;
+  if (r->i < c)
     return 0;
-  }
   return ebadmsg();
 }

--- a/test/net/http/parsehttpmessage_test.c
+++ b/test/net/http/parsehttpmessage_test.c
@@ -464,6 +464,26 @@ TEST(ParseHttpMessage, testBufferClampOnResume) {
   EXPECT_STREQ("x", gc(slice(m, req->headers[kHttpHost])));
 }
 
+TEST(ParseHttpMessage, testResumeWhenCapacityEqualsReceivedPlusOne) {
+  // Regression: when the buffer capacity is exactly one byte larger than
+  // the number of bytes received (c == n + 1), an inner loop that breaks
+  // via `if (++r->i == n) break;` leaves r->i == n, and the outer for loop
+  // then increments it to n + 1. If the position is not clamped before the
+  // capacity comparison, `if (r->i < c)` evaluates `n+1 < n+1` (false) and
+  // the parser wrongly returns EBADMSG for a message that is merely
+  // incomplete. It must instead return 0 (need more data) and leave r->i
+  // pointing no further than the received bytes.
+  InitHttpMessage(req, kHttpRequest);
+  EXPECT_EQ(0, ParseHttpMessage(req, "GET", 3, 4));
+  EXPECT_LE(req->i, 3);
+  // A subsequent call with the full message must still parse correctly,
+  // i.e. the paused byte was not skipped.
+  static const char m[] = "GET / HTTP/1.0\r\n\r\n";
+  EXPECT_EQ(strlen(m), ParseHttpMessage(req, m, strlen(m), strlen(m)));
+  EXPECT_STREQ("GET", method());
+  EXPECT_STREQ("/", gc(slice(m, req->uri)));
+}
+
 TEST(ParseHttpMessage, testResumeAfterPartialMethod) {
   // Feed a request where the method is split across two calls.
   // This exercises the kHttpStateMethod inner loop boundary.


### PR DESCRIPTION
## Summary

Fixes a one-byte-premature `EBADMSG` in `ParseHttpMessage()` when a parse is resumed and the buffer capacity is exactly one byte larger than the bytes received so far (`c == n + 1`). This corresponds to the `parsehttpmessage` clamp-ordering item ("the resume clamp is placed one line too late") in the upstream-diff security review (`PLAN.md`).

This was developed red→green: the test was written first and observed failing, then the fix was applied and the test (plus the full file) observed passing.

## The bug

`ParseHttpMessage()` pauses an incomplete parse by returning `0` so the caller can read more bytes and resume. The inner state-machine loops break with `if (++r->i == n) break;`, leaving `r->i == n`; the outer `for (; r->i < n; ++r->i)` then increments it once more to `n + 1`.

The trailing logic clamped this overshoot back to `n`, but only *after* the `if (r->i < c)` test:

```c
if (r->i < c) {
  if (r->i > n)
    r->i = n;
  return 0;
}
return ebadmsg();
```

When `c == n + 1`, the unclamped `r->i == n + 1` fails `n+1 < n+1` and the function returns `ebadmsg()` for a message that is merely incomplete — corrupting the parse state so a subsequent resumed call fails too.

## The fix

Clamp `r->i` to `n` *before* the capacity comparison, so the boundary case returns `0` (need more data) as intended:

```c
if (r->i > n)
  r->i = n;
if (r->i < c)
  return 0;
return ebadmsg();
```

## Test

Added `testResumeWhenCapacityEqualsReceivedPlusOne`, which feeds `ParseHttpMessage(req, "GET", 3, 4)` (capacity `n+1`) and asserts it returns `0` rather than `-1`, then confirms a follow-up full-message parse still succeeds (the paused byte is not skipped).

- Before fix: `4 / 173 tests failed`
- After fix: all 173 tests pass

Verified by building and running `o//test/net/http/parsehttpmessage_test`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PjngB8T4ULKxPwhjsZwgX5)_