### PR TITLE
lua: export unix.O_PATH constant

### DIFF
--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -4368,6 +4368,7 @@ int LuaUnix(lua_State *L) {
   LuaSetIntField(L, "O_NOATIME", O_NOATIME);
   LuaSetIntField(L, "O_CLOEXEC", O_CLOEXEC);
   LuaSetIntField(L, "O_UNLINK", O_UNLINK);
+  LuaSetIntField(L, "O_PATH", _O_PATH);
 
   // seek() whence
   LuaSetIntField(L, "SEEK_SET", SEEK_SET);

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -4971,6 +4971,10 @@ unix = {
     O_NOFOLLOW = nil,
     --- @type integer automatically delete file upon close()
     O_UNLINK = nil,
+    --- @type integer open a path reference only, without read/write access
+    --- (Linux only; fails with EINVAL elsewhere). Usable with landlock
+    --- rule paths and *at() calls even when the path itself is unreadable.
+    O_PATH = nil,
     --- @type integer it's complicated (zero on non-Linux/Apple)
     O_DSYNC = nil,
     --- @type integer it's complicated (zero on non-Linux/Apple)


### PR DESCRIPTION
# Summary

`lunix`'s `landlock_add_rule` documentation already instructs callers to open rule paths with `unix.open("/usr", unix.O_PATH)`, but the constant was never registered in the unix module — reading `unix.O_PATH` returned `nil`. Any caller following the documented pattern passed a nil flag: a bitwise-or against it throws, and a bare `unix.open(path, unix.O_PATH)` silently degraded to `flags = 0` (a normal read-open, which fails for unreadable paths and grants the wrong access to landlock).

This registers `O_PATH` from the internal `_O_PATH` macro (`0x00200000`) alongside the other `O_*` constants, and documents it in `definitions.lua` so generated type declarations pick it up.

## Correctness

- **Value**: `_O_PATH = 0x00200000`, the Linux `O_PATH` flag value (same on x86_64 and aarch64 in `libc/sysv/consts/o.h`).
- **Linux**: `__xoflags()` already whitelists `_O_PATH` and passes it straight through to `openat(2)` (`flags2 = flags`).
- **Non-Linux**: `__xoflags()` returns `EINVAL` for `_O_PATH`, which is correct — `O_PATH` is a Linux-only flag. So `unix.open(path, unix.O_PATH)` works on Linux and cleanly errors elsewhere, exactly what landlock consumers want.

## Verification

`make m=x86_64 o/x86_64/tool/lua/lua.dbg` + full `o/x86_64/tool/lua/test` pass. Direct check on the built binary:

```
O_PATH: 2097152  0x200000
open(/usr, O_PATH): 3  nil        -- opens, no error
O_PATH open+close ok
definitions has O_PATH: true
```

## Context

Downstream, whilp/cosmic's `cosmic.landlock` currently pins the `O_PATH` value locally to work around this gap (whilp/cosmic#417). Once this ships in a cosmos release and cosmic bumps its pin, that local constant is replaced with `unix.O_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R49PXA2xphxt7mfNjqwJ2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01R49PXA2xphxt7mfNjqwJ2T)_