### PR TITLE
lua/unix: add sysconf() and uname() bindings; type Stat fields

### DIFF
--- a/test/tool/net/sysconf_test.lua
+++ b/test/tool/net/sysconf_test.lua
@@ -1,0 +1,53 @@
+-- Copyright 2026 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+assert(unix.pledge("stdio"))
+
+-- The name constants are exported as integers.
+assert(math.type(unix.SC_NPROCESSORS_ONLN) == "integer")
+assert(math.type(unix.SC_NPROCESSORS_CONF) == "integer")
+assert(math.type(unix.SC_PAGESIZE) == "integer")
+assert(math.type(unix.SC_CLK_TCK) == "integer")
+assert(math.type(unix.SC_OPEN_MAX) == "integer")
+assert(math.type(unix.SC_ARG_MAX) == "integer")
+assert(math.type(unix.SC_CHILD_MAX) == "integer")
+
+-- Number of online processors is a positive integer.
+local nonln = assert(unix.sysconf(unix.SC_NPROCESSORS_ONLN))
+assert(math.type(nonln) == "integer")
+assert(nonln >= 1)
+
+-- The machine can never have fewer configured than online CPUs.
+local nconf = assert(unix.sysconf(unix.SC_NPROCESSORS_CONF))
+assert(nconf >= nonln)
+
+-- Page size is a positive power of two (>= 4096 on supported hosts).
+local pagesize = assert(unix.sysconf(unix.SC_PAGESIZE))
+assert(math.type(pagesize) == "integer")
+assert(pagesize >= 4096)
+assert((pagesize & (pagesize - 1)) == 0)
+
+-- Clock ticks per second is positive.
+local clktck = assert(unix.sysconf(unix.SC_CLK_TCK))
+assert(clktck > 0)
+
+-- An unrecognized name fails with nil, unix.Errno holding EINVAL rather
+-- than throwing or returning a bogus value.
+local rc, err = unix.sysconf(-1)
+assert(rc == nil)
+assert(err)
+assert(err:errno() == unix.EINVAL)
+
+print("All sysconf tests passed!")

--- a/test/tool/net/uname_test.lua
+++ b/test/tool/net/uname_test.lua
@@ -1,0 +1,36 @@
+-- Copyright 2026 Will Maier
+--
+-- Permission to use, copy, modify, and/or distribute this software for
+-- any purpose with or without fee is hereby granted, provided that the
+-- above copyright notice and this permission notice appear in all copies.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+-- WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+-- WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+-- AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+-- DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+-- PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+-- TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+-- PERFORMANCE OF THIS SOFTWARE.
+
+assert(unix.pledge("stdio"))
+
+local u = assert(unix.uname())
+assert(type(u) == "table")
+
+-- Every documented field is present and a string.
+for _, field in ipairs({
+  "sysname", "nodename", "release", "version", "machine", "domainname"
+}) do
+  assert(type(u[field]) == "string", "missing field: " .. field)
+end
+
+-- The OS name and hardware type are always populated.
+assert(#u.sysname > 0)
+assert(#u.machine > 0)
+
+-- Calling it twice yields a stable operating-system name.
+local u2 = assert(unix.uname())
+assert(u2.sysname == u.sysname)
+
+print("All uname tests passed!")

--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -39,6 +39,7 @@
 #include "libc/calls/struct/statfs.h"
 #include "libc/calls/struct/timespec.h"
 #include "libc/calls/struct/timeval.h"
+#include "libc/calls/struct/utsname.h"
 #include "libc/calls/struct/winsize.h"
 #include "libc/calls/ucontext.h"
 #include "libc/calls/weirdtypes.h"
@@ -4037,6 +4038,62 @@ static void LuaUnixDirObj(lua_State *L) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// SYSTEM INFORMATION
+
+// unix.sysconf(name:int)
+//     ├─→ value:int
+//     └─→ nil, unix.Errno
+//
+// Queries a configurable system limit or value, e.g.
+//
+//     unix.sysconf(unix.SC_NPROCESSORS_ONLN)  // online cpu count
+//     unix.sysconf(unix.SC_PAGESIZE)          // mmap() page size
+//     unix.sysconf(unix.SC_CLK_TCK)           // clock ticks per second
+//
+// Returns `nil, unix.Errno` with `EINVAL` when `name` isn't recognized.
+static int LuaUnixSysconf(lua_State *L) {
+  long rc;
+  int olderr = errno;
+  int name = luaL_checkinteger(L, 1);
+  errno = 0;
+  rc = sysconf(name);
+  if (rc == -1 && errno) {
+    return LuaUnixSysretErrno(L, "sysconf", olderr);
+  }
+  errno = olderr;
+  lua_pushinteger(L, rc);
+  return 1;
+}
+
+// unix.uname()
+//     ├─→ {sysname:str, nodename:str, release:str,
+//     │    version:str, machine:str, domainname:str}
+//     └─→ nil, unix.Errno
+//
+// Returns identity of the current operating system as a table.
+static int LuaUnixUname(lua_State *L) {
+  struct utsname u;
+  int olderr = errno;
+  if (uname(&u) == -1) {
+    return LuaUnixSysretErrno(L, "uname", olderr);
+  }
+  lua_newtable(L);
+  lua_pushstring(L, u.sysname);
+  lua_setfield(L, -2, "sysname");
+  lua_pushstring(L, u.nodename);
+  lua_setfield(L, -2, "nodename");
+  lua_pushstring(L, u.release);
+  lua_setfield(L, -2, "release");
+  lua_pushstring(L, u.version);
+  lua_setfield(L, -2, "version");
+  lua_pushstring(L, u.machine);
+  lua_setfield(L, -2, "machine");
+  lua_pushstring(L, u.domainname);
+  lua_setfield(L, -2, "domainname");
+  return 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // UNIX module
 
 static const luaL_Reg kLuaUnix[] = {
@@ -4173,6 +4230,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"strsignal", LuaUnixStrsignal},      // turn signal into string
     {"symlink", LuaUnixSymlink},          // create symbolic link
     {"sync", LuaUnixSync},                // flushes files and disks
+    {"sysconf", LuaUnixSysconf},          // query system configuration value
     {"syslog", LuaUnixSyslog},            // logs to system log
     {"tcgetattr", LuaUnixTcgetattr},      // get terminal attributes
     {"tcsetattr", LuaUnixTcsetattr},      // set terminal attributes
@@ -4180,6 +4238,7 @@ static const luaL_Reg kLuaUnix[] = {
     {"tmpfd", LuaUnixTmpfd},              // create anonymous file
     {"truncate", LuaUnixTruncate},        // shrink or extend file medium
     {"umask", LuaUnixUmask},              // set default file mask
+    {"uname", LuaUnixUname},              // get operating system identity
     {"unlink", LuaUnixUnlink},            // remove file
     {"unmount", LuaUnixUnmount},          // unmount filesystem
     {"unsetenv", LuaUnixUnsetenv},        // unset environment variable
@@ -4406,6 +4465,15 @@ int LuaUnix(lua_State *L) {
   LuaSetIntField(L, "PRIO_PROCESS", PRIO_PROCESS);
   LuaSetIntField(L, "PRIO_PGRP", PRIO_PGRP);
   LuaSetIntField(L, "PRIO_USER", PRIO_USER);
+
+  // sysconf() names
+  LuaSetIntField(L, "SC_ARG_MAX", _SC_ARG_MAX);
+  LuaSetIntField(L, "SC_CHILD_MAX", _SC_CHILD_MAX);
+  LuaSetIntField(L, "SC_CLK_TCK", _SC_CLK_TCK);
+  LuaSetIntField(L, "SC_OPEN_MAX", _SC_OPEN_MAX);
+  LuaSetIntField(L, "SC_PAGESIZE", _SC_PAGESIZE);
+  LuaSetIntField(L, "SC_NPROCESSORS_CONF", _SC_NPROCESSORS_CONF);
+  LuaSetIntField(L, "SC_NPROCESSORS_ONLN", _SC_NPROCESSORS_ONLN);
 
   // wait() options
   LuaSetIntField(L, "WNOHANG", WNOHANG);

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -5089,6 +5089,21 @@ unix = {
     --- @type integer getpriority/setpriority: target is a user id
     PRIO_USER = nil,
 
+    --- @type integer sysconf: maximum length of arguments to exec()
+    SC_ARG_MAX = nil,
+    --- @type integer sysconf: maximum simultaneous processes per user id
+    SC_CHILD_MAX = nil,
+    --- @type integer sysconf: clock ticks per second
+    SC_CLK_TCK = nil,
+    --- @type integer sysconf: maximum number of open files per process
+    SC_OPEN_MAX = nil,
+    --- @type integer sysconf: size of a memory page in bytes
+    SC_PAGESIZE = nil,
+    --- @type integer sysconf: number of processors configured
+    SC_NPROCESSORS_CONF = nil,
+    --- @type integer sysconf: number of processors currently online
+    SC_NPROCESSORS_ONLN = nil,
+
     --- @type integer
     RUSAGE_BOTH = nil,
     --- @type integer
@@ -6602,6 +6617,33 @@ function unix.setresgid(real, effective, saved) end
 ---@param newmask integer
 ---@return integer oldmask
 function unix.umask(newmask) end
+
+--- Queries a configurable system limit or value.
+---
+--- `name` selects which value to return, e.g.
+---
+---     unix.sysconf(unix.SC_NPROCESSORS_ONLN)  -- online cpu count
+---     unix.sysconf(unix.SC_PAGESIZE)          -- mmap() page size
+---     unix.sysconf(unix.SC_CLK_TCK)           -- clock ticks per second
+---
+--- Returns `nil` with an `EINVAL` errno when `name` isn't recognized.
+---@param name integer
+---@return integer value
+---@nodiscard
+---@overload fun(name: integer): nil, error: unix.Errno
+function unix.sysconf(name) end
+
+--- Returns identity of the current operating system.
+---
+--- Example:
+---
+---     local u = assert(unix.uname())
+---     print(u.sysname, u.release, u.machine)
+---
+---@return { sysname: string, nodename: string, release: string, version: string, machine: string, domainname: string } uts
+---@nodiscard
+---@overload fun(): nil, error: unix.Errno
+function unix.uname() end
 
 --- Generates a log message, which will be distributed by syslogd.
 ---
@@ -8726,15 +8768,15 @@ function unix.Stat:dev() end
 --- may be used to extract the device numbers.
 function unix.Stat:rdev() end
 
----@return any
+---@return integer nlink Number of hard links to the file.
 ---@nodiscard
 function unix.Stat:nlink() end
 
----@return any
+---@return integer gen Inode generation number.
 ---@nodiscard
 function unix.Stat:gen() end
 
----@return any
+---@return integer flags User-defined flags on the file.
 ---@nodiscard
 function unix.Stat:flags() end
 


### PR DESCRIPTION
## Summary

Implements the tractable **upstream (`whilp/cosmopolitan`) items** called for by the cosmic codebase audit ([`whilp/cosmic#420`](https://github.com/whilp/cosmic/pull/420), `docs/audit-2026-07.md`) that were still missing in this fork's HEAD. Most of the audit's Phase-0 annotation work (U1 Errno returns, U3 integer constants, and the U8 digest/`DecodeHex`/`GetTime` declarations) is already present here — this PR fills the remaining verified gaps.

### U8 — expose existing system-info C to the Lua `unix` module

The audit (Dimension 4.2 / U8) notes cosmic wants `nproc` / page-size / `uname` but "no `sysconf`/`uname` binding exists." The underlying C (`sysconf()`, `uname()`) is already in the binary; it just wasn't reachable from Lua.

- **`unix.sysconf(name)` → `integer` | `nil, unix.Errno`** — wraps `sysconf(3)`. Sets `errno = 0` before the call and only reports an error when `sysconf` returns `-1` *and* `errno` is set, so POSIX "indeterminate" (`-1`, no errno) is passed through and an unknown name yields `nil, EINVAL` (never throws). Exports the name constants `SC_ARG_MAX`, `SC_CHILD_MAX`, `SC_CLK_TCK`, `SC_OPEN_MAX`, `SC_PAGESIZE`, `SC_NPROCESSORS_CONF`, `SC_NPROCESSORS_ONLN`.
- **`unix.uname()` → `table` | `nil, unix.Errno`** — wraps `uname(2)`, returning `{sysname, nodename, release, version, machine, domainname}`.

### U2 — correct wrong LuaLS annotations (consumed by cosmic's type generator)

- `unix.Stat:nlink()` / `:gen()` / `:flags()` were annotated `@return any`; the C implementations return integers via `ReturnInteger`, so they are now declared `@return integer`. This deletes a downstream re-assertion cast in cosmic's `fs_types.tl`.

`definitions.lua` also gains the matching `unix.sysconf` / `unix.uname` function annotations and `SC_*` constant declarations so a `cosmos` bump carries the typed surface into cosmic automatically.

### Notes on the rest of the audit's upstream list

- **U1 / U3 / U8-digests**: already present in this fork's HEAD (newer than the audited `f91e36c`); no change needed.
- **U9 (Fetch TLS verify default)**: verified already fail-closed — `tool/net/lfetch.c:288` hardcodes `MBEDTLS_SSL_VERIFY_REQUIRED` for the `Fetch` binding, so the audit's silent-MITM concern does not apply here.
- **U4 (mbedTLS socket wrap), U5 (IPv6 sockets + resolver), U6 (resolve-with-timeout), U7 (ifreq/rtnetlink)**: each is a substantial net-new C feature and is intentionally left out of this PR; they warrant dedicated changes.

## Test plan

Red/green TDD. New Lua tests run under the existing `test/tool/net/*_test.lua.runs` harness (`o/.../tool/net/redbean -i …`):

- `test/tool/net/sysconf_test.lua` — `SC_*` constants are integers; `NPROCESSORS_ONLN >= 1`; `NPROCESSORS_CONF >= ONLN`; page size is a power of two ≥ 4096; `CLK_TCK > 0`; unknown name returns `nil` + `unix.Errno` with `EINVAL`.
- `test/tool/net/uname_test.lua` — every field present as a string; `sysname`/`machine` non-empty; `sysname` stable across calls.

Both fail against the unmodified binary (missing symbols) and pass after the change. Verified locally: `uname → Linux 6.18.5 x86_64`, `nproc=4 pagesize=4096 clk=100`, `sysconf(99999) → nil, EINVAL`. Existing `lunix_test.lua`, `setenv_test.lua`, `unsetenv_test.lua`, `clearenv_test.lua`, `getlogin_test.lua` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015841xCgAHZ9WKU1tnTRhMb

---
_Generated by [Claude Code](https://claude.ai/code/session_015841xCgAHZ9WKU1tnTRhMb)_