### PR TITLE
lua/unix: fix clearenv (and 4 more) dropped @return annotations; lint the syntax

### DIFF
--- a/tool/lua/test_definitions_coverage.lua
+++ b/tool/lua/test_definitions_coverage.lua
@@ -16,6 +16,10 @@
 -- fails this test -- annotate the binding, do not append to the allowlist. When
 -- you annotate an allowlisted symbol (or drop it from the C), remove it here or
 -- the stale-entry check fails.
+--
+-- This test also lints annotation SYNTAX (check 3): a LuaLS tag written
+-- `--- @tag` (with a space after the dashes) is silently ignored, so the
+-- coverage checks above can pass while the annotation does nothing.
 
 local function slurp(path)
   local f = assert(io.open(path, "r"), "cannot open " .. path)
@@ -125,6 +129,25 @@ end
 assert(#stale == 0,
   "the annotation-coverage allowlist has stale entries (remove them so the\n" ..
   "ratchet stays tight):\n  " .. table.concat(stale, "\n  "))
+
+-- 3) Malformed annotation syntax: a LuaLS tag must be written `---@tag`, with
+-- no space between the comment dashes and the `@`. A stray `--- @tag` is
+-- treated as ordinary comment prose, so LuaLS -- and the downstream gentype
+-- generator -- silently ignore it: a function's @return/@overload vanishes and
+-- it renders as returning nothing (this is exactly how unix.clearenv lost its
+-- `boolean, unix.Errno` return). Catch it here so it can't recur.
+local malformed = {}
+local lineno = 0
+for line in (D .. "\n"):gmatch("([^\n]*)\n") do
+  lineno = lineno + 1
+  if line:match("^%-%-%-[ \t]+@%a") then
+    malformed[#malformed + 1] = "line " .. lineno .. ": " .. line
+  end
+end
+assert(#malformed == 0,
+  "these annotation lines put a space after `---`, so LuaLS and gentype\n" ..
+  "silently drop them (write `---@tag`, not `--- @tag`):\n  " ..
+  table.concat(malformed, "\n  "))
 
 print("definitions coverage: " ..
   tostring(#sorted_keys(reg_fns)) .. " functions, " ..

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -2077,11 +2077,11 @@ function VisualizeControlCodes(str) end
 function Underlong(str) end
 
 --- Generate a uuid_v4
---- @return string
+---@return string
 function UuidV4() end
 
 --- Generate a uuid_v7
---- @return string
+---@return string
 function UuidV7() end
 
 ---@param x integer
@@ -5774,8 +5774,8 @@ function unix.unsetenv(name) end
 --- This wraps the C `clearenv()` function to allow Lua scripts to remove
 --- all environment variables at once.
 ---
---- @return true
---- @overload fun(): nil, error: unix.Errno
+---@return true
+---@overload fun(): nil, error: unix.Errno
 function unix.clearenv() end
 
 --- Gets login name of current user.
@@ -5783,8 +5783,8 @@ function unix.clearenv() end
 --- This wraps the C `getlogin()` function to retrieve the login name
 --- associated with the current session.
 ---
---- @return string login name
---- @overload fun(): nil, error: unix.Errno
+---@return string login name
+---@overload fun(): nil, error: unix.Errno
 function unix.getlogin() end
 
 --- Creates a new process mitosis style.
@@ -8949,7 +8949,7 @@ function unix.Rusage:nsignals() end
 --- remaining time to the system.
 function unix.Rusage:nvcsw() end
 
---- @return integer count number of non-consensual context switches.
+---@return integer count number of non-consensual context switches.
 ---
 --- This number is a bad thing. It means your redbean was preempted by a
 --- higher priority process after failing to finish its work, within the


### PR DESCRIPTION
## Summary

`unix.clearenv` rendered as `function()` (no return) in downstream type generators, even though its C binding already returns `true` / `nil, unix.Errno` via `SysretBool`. The cause was purely the annotation: it was written with a **space** after the comment dashes —

```
--- @return true
--- @overload fun(): nil, error: unix.Errno
```

LuaLS (and cosmic's `gentype`) only recognize the no-space form `---@tag`; a `--- @tag` is treated as ordinary comment prose and silently ignored. So the `@return`/`@overload` vanished and the function looked like it returned nothing. Removing the space restores it.

The same malformed spacing was hiding annotations on four other symbols, all fixed here:
- `unix.getlogin` (`@return string` + `@overload`)
- `unix.Rusage:nivcsw` (`@return integer`)
- `UuidV4`, `UuidV7` (`@return string`)

## Preventing recurrence

`tool/lua/test_definitions_coverage.lua` already ratchets annotation *coverage*; it now also lints annotation *syntax* (check 3): any `--- @tag` (space after `---`) fails the test with its line number. Coverage could previously pass while an annotation did nothing — this closes that gap.

## Verification

Confirmed with cosmic's `gentype` against the fixed `definitions.lua`:

```
clearenv -> function(): boolean, Errno
getlogin -> function(): string, Errno
```

`test_definitions_coverage.lua` passes on the fixed file (151 functions, 526 constants, 0 malformed), and the new check correctly flags a reintroduced `--- @tag` while ignoring the valid `---@tag` and prose containing `@`.

## Downstream

Once released and pinned in cosmic, this lets `cosmic.env.clearenv` drop its remaining `as(boolean, any)` cast (the last one left after whilp/cosmic#424).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM5Z3Qq9bc7XXVCuh4NiQG)_