### PR TITLE
lua/unix: fdopendir returns just the Dir, not a phantom iterator function

### DIFF
--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -4001,7 +4001,7 @@ static int LuaUnixOpendir(lua_State *L) {
 }
 
 // unix.fdopendir(fd:int)
-//     ├─→ next:function, state:unix.Dir
+//     ├─→ state:unix.Dir
 //     └─→ nil, unix.Errno
 static int LuaUnixFdopendir(lua_State *L) {
   DIR *dir;

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -8729,7 +8729,7 @@ function unix.opendir(path) end
 --- The returned `unix.Dir` takes ownership of the file descriptor
 --- and will close it automatically when garbage collected.
 ---
----@return function next, unix.Dir state
+---@return unix.Dir state
 ---@nodiscard
 ---@overload fun(fd: integer): nil, error: unix.Errno
 function unix.fdopendir(fd) end

--- a/tool/net/help.txt
+++ b/tool/net/help.txt
@@ -4827,7 +4827,7 @@ UNIX MODULE
         Write('</ul>\r\n')
 
   unix.fdopendir(fd:int)
-      ├─→ next:function, state:unix.Dir
+      ├─→ state:unix.Dir
       └─→ nil, unix.Errno
 
     Opens directory for listing its contents, via an fd.


### PR DESCRIPTION
## Summary

`unix.fdopendir` is annotated `---@return function next, unix.Dir state`, declaring a leading iterator `function` the binding never returns.

`LuaUnixFdopendir` calls `ReturnDir` — the *same* helper `LuaUnixOpendir` uses — which pushes **exactly one value**, the `unix.Dir`, and returns `1`. The `unix.Dir` userdata is self-iterating: its metatable binds `__call → LuaUnixDirRead`, which is why `for name in assert(unix.opendir(dir))` works with the Dir alone. There is no separate `next` function for either `opendir` or `fdopendir`.

The wrong annotation is load-bearing for consumers of the generated types (e.g. cosmic's `gentype`, which turns it into `function(fd: number): function, Dir, Errno`): a caller reading two success values gets the `Dir` in the second slot and `nil` in the first, so a straightforward `local dir = unix.fdopendir(fd)` yields `nil`.

## Change

Correct three in-sync copies to a single `unix.Dir` return, matching `opendir`:
- `tool/net/definitions.lua` — the LuaLS annotation (`---@return unix.Dir state`)
- `third_party/lua/lunix.c` — the banner comment above `LuaUnixFdopendir`
- `tool/net/help.txt` — the embedded `unix.fdopendir` help entry

No behavioral/C code change — `ReturnDir` already returns one value. The `---@overload fun(fd: integer): nil, error: unix.Errno` failure path is unchanged.

## Test plan

- No runtime behavior changes; libc `fdopendir` tests (`test/libc/stdio/dirstream_test.c`) are unaffected.
- Downstream, cosmic's `gentype` will now emit `fdopendir: function(fd: number): Dir, Errno`, matching `opendir` and the actual runtime shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GU1VyZcfzXAhFzmii6unca)_