### PR TITLE
ljson: pre-size decoded tables to skip rehash-on-grow

### DIFF
--- a/tool/net/ljson.c
+++ b/tool/net/ljson.c
@@ -240,7 +240,10 @@ static struct DecodeJson Parse(struct lua_State *L, const char *p,
       case '[':  // Array
         if (context & (COLON | COMMA | KEY))
           goto OnColonCommaKey;
-        lua_newtable(L);  // +1
+        // Pre-size the array part so small/medium arrays skip the
+        // rehash-on-grow cycles lua_rawseti would otherwise pay; 8 covers
+        // the common short array without meaningful waste on tiny ones.
+        lua_createtable(L, 8, 0);  // +1
         for (context = ARRAY, i = 0;;) {
           r = Parse(L, p, e, context, depth - 1, bsp);  // +2
           if (UNLIKELY(r.rc == -1)) {
@@ -278,7 +281,9 @@ static struct DecodeJson Parse(struct lua_State *L, const char *p,
       case '{':  // Object
         if (context & (COLON | COMMA | KEY))
           goto OnColonCommaKey;
-        lua_newtable(L);  // +1
+        // Pre-size the hash part so objects up to 8 keys populate without
+        // a hash-part rehash; larger objects still amortize from there.
+        lua_createtable(L, 0, 8);  // +1
         context = KEY | OBJECT;
         for (;;) {
           r = Parse(L, p, e, context, depth - 1, bsp);  // +2


### PR DESCRIPTION
## What

`Parse()` in `tool/net/ljson.c` created every decoded array and object with `lua_newtable(L)` — zero pre-allocated slots — then filled them element by element with `lua_rawseti` / `lua_settable`. Lua grows a table by rehashing in power-of-two steps, so a large array pays ~log2(n) realloc cycles and every object with several keys pays hash-part growth.

This pre-sizes instead with `lua_createtable(L, narr, nrec)`: 8 array slots for arrays, 8 hash slots for objects. A fixed small guess (no lookahead) covers the common short array / few-key object without a rehash, and caps worst-case waste on tiny tables at a few slots.

## Correctness

Contract unchanged — same decoded values. Verified the empty-array `[]` kludge and empty-object `{}` round-trips still hold, and that 9-key objects / 10-element arrays decode intact. `make -j$(nproc) o//tool/lua/test` passes (binding tests + the `definitions.lua` annotation-coverage ratchet). `DecodeJson`'s signature is unchanged, so no `definitions.lua` update or cosmic-side type regen is needed.

## Measurement

Measured with cosmic's harness against two local **default-mode** builds that differ only by this diff (`COSMO_LUA=… bin/make perf-bin`), A/B repeated to separate the real win from this shared runner's microbenchmark noise:

```
json_decode_large    1.16 ms/op -> ~0.78 ms/op   ~-30%
json_decode_small    1.08 µs/op -> ~0.74 µs/op   ~-31%
json_roundtrip_small                              ~-16%
alloc unchanged (the ~375 KB/op floor is the decoded graph itself)
```

The win reproduced on every one of ~8 runs. Short syscall/fixed-overhead scenarios (`hash_sha256_small`, `startup_run_*`) tripped the perf-compare bar, but were falsified as runner noise by (a) a back-to-back controlled A/B — both builds measure identically in isolation — and (b) an A/A control where the *same unmodified binary* vs its own baseline flags `hash_sha256_small` +10.5% and `startup_run_teal` +10.4%.

End-to-end confirmation on the pinned release will happen at the cosmos bump on the cosmic side per `lib/perf/optimize/cosmopolitan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3LLKk1LBKarc5bd2Q3LsC)_