### PR TITLE
json encoder: collapse sorted-path per-key mallocs into one buffer

### DIFF
--- a/third_party/lua/luaencodejsondata.c
+++ b/third_party/lua/luaencodejsondata.c
@@ -22,12 +22,12 @@
 #include "libc/intrin/likely.h"
 #include "libc/log/log.h"
 #include "libc/log/rop.internal.h"
+#include "libc/mem/alg.h"
 #include "libc/mem/gc.h"
 #include "libc/mem/mem.h"
 #include "libc/runtime/runtime.h"
 #include "libc/runtime/stack.h"
 #include "libc/stdio/append.h"
-#include "libc/stdio/strlist.internal.h"
 #include "libc/str/str.h"
 #include "libc/sysv/consts/auxv.h"
 #include "net/http/escape.h"
@@ -130,39 +130,69 @@ OnError:
   return -1;
 }
 
+static int CompareJsonEntries(const void *p1, const void *p2) {
+  const char *a = *(const char **)p1;
+  const char *b = *(const char **)p2;
+  for (; *a == *b; a++, b++) {
+    if (!*a)
+      break;
+  }
+  return (*a & 0xff) - (*b & 0xff);
+}
+
 static int SerializeSorted(lua_State *L, char **buf, struct Serializer *z,
                            int depth, bool multi) {
-  int i;
-  struct StrList sl = {0};
+  // Serialize each `"key":value` entry into one contiguous buffer,
+  // NUL-separated, then sort pointers into it. This produces byte-for-byte
+  // the same output as sorting a StrList of individually-allocated entries,
+  // but replaces the per-key malloc/free churn with a single growable buffer
+  // plus one pointer array.
+  int i, n = 0;
+  char *s;
+  char *ent = 0;
+  char **ptrs = 0;
   lua_pushnil(L);
   while (lua_next(L, -2)) {
     if (lua_type(L, -2) == LUA_TSTRING) {
-      RETURN_ON_ERROR(i = AppendStrList(&sl));
-      RETURN_ON_ERROR(SerializeString(L, sl.p + i, -2, z));
-      RETURN_ON_ERROR(appendw(sl.p + i, z->conf.pretty ? READ16LE(": ") : ':'));
-      RETURN_ON_ERROR(Serialize(L, sl.p + i, -1, z, depth + 1));
+      RETURN_ON_ERROR(SerializeString(L, &ent, -2, z));
+      RETURN_ON_ERROR(appendw(&ent, z->conf.pretty ? READ16LE(": ") : ':'));
+      RETURN_ON_ERROR(Serialize(L, &ent, -1, z, depth + 1));
+      RETURN_ON_ERROR(appendw(&ent, 0));  // NUL separator between entries
+      ++n;
       lua_pop(L, 1);
     } else {
       z->reason = "json objects must only use string keys";
       goto OnError;
     }
   }
-  SortStrList(&sl);
+  if (n) {
+    if (!(ptrs = malloc(n * sizeof(*ptrs)))) {
+      z->reason = "out of memory";
+      goto OnError;
+    }
+    for (i = 0, s = ent; i < n; ++i) {
+      ptrs[i] = s;
+      s += strlen(s) + 1;
+    }
+    qsort(ptrs, n, sizeof(*ptrs), CompareJsonEntries);
+  }
   RETURN_ON_ERROR(SerializeObjectStart(buf, z, depth, multi));
-  for (i = 0; i < sl.i; ++i) {
+  for (i = 0; i < n; ++i) {
     if (i) {
       RETURN_ON_ERROR(appendw(buf, ','));
       if (multi) {
         RETURN_ON_ERROR(SerializeObjectIndent(buf, z, depth + 1));
       }
     }
-    RETURN_ON_ERROR(appends(buf, sl.p[i]));
+    RETURN_ON_ERROR(appends(buf, ptrs[i]));
   }
   RETURN_ON_ERROR(SerializeObjectEnd(buf, z, depth, multi));
-  FreeStrList(&sl);
+  free(ptrs);
+  free(ent);
   return 0;
 OnError:
-  FreeStrList(&sl);
+  free(ptrs);
+  free(ent);
   return -1;
 }
 


### PR DESCRIPTION
## Summary

`SerializeSorted()` in `third_party/lua/luaencodejsondata.c` serialized each object's `"key":value` entry into a **separately-allocated** `StrList` buffer, sorted the pointer array, then concatenated. A k-key object paid ~k malloc/grow/free cycles plus the StrList pointer array.

`EncodeJson` defaults to `sorted=true`, so this is the common path. On the perf harness's 1000-object payload, a direct A/B on the raw `lua` measured the sorted path at ~1290 µs/op vs ~920 µs/op unsorted — ~28% of encode time, which made `json_encode_large` *slower* than `json_decode_large` despite decode having to build the whole Lua graph.

This change serializes every entry into **one contiguous NUL-separated buffer** (`appendw(&b, 0)` appends exactly one NUL), then builds a pointer array into it and `qsort`s with the same bytewise-strcmp comparator. Per-object allocation drops from ~k mallocs to one `ent` buffer + one `ptrs` array.

## Output is byte-for-byte identical

Same serialized entry bytes, same NUL termination, same comparator → same ordering. Verified with a fuzz of prefix-sharing keys, keys containing bytes < 0x22 (space, `!`), quotes, control chars, unicode, and deep nesting under `sorted` / `sorted+pretty` / custom-indent, comparing the pre-change binary vs the patched one:

- all **sorted** output is byte-identical
- the only diffs are on `sorted=false` output — which the **old** binary also differs from *itself* across two runs, because Lua 5.4 seeds its string hash randomly and that drives `lua_next` order. Pre-existing nondeterminism, not this change.

`EncodeJson`'s contract (return shape, `definitions.lua` annotations) is unchanged — no annotation/type regen needed.

## Measurements

Direct A/B on the raw `lua` (best-of-8 × 3000 iters, default sorted — dodges scenario-wrapper + runner noise):

```
encode 1000-object payload   ~1250 µs/op -> ~1130 µs/op   ~-10%   (reproduced every repeat)
```

End-to-end via cosmic's `perf-compare` (local build A/B, same tree except this diff):

```
json_encode_large   1.25 ms -> 1.19 ms   -5.2%   (diluted into its ±10% noise bar)
33 scenarios: 0 regression
```

The `json_decode_large +12%` that `perf-compare` flagged is layout noise: `perf-selfcheck` (A/A, the patched binary vs itself) swings decode 851→867 µs at ±6–10% and decode code was not touched.

## Correctness gates

- `make -j$(nproc) o//tool/lua/test` — binding tests + `definitions.lua` annotation-coverage ratchet: **pass**
- cosmic `bin/make test only=json` against the local binary: **pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zo6kuvzgFfc6JgjHoBEUB

---
_Generated by [Claude Code](https://claude.ai/code/session_018zo6kuvzgFfc6JgjHoBEUB)_