### PR TITLE
perf: point backlog reference at GitHub issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,9 @@ noise-aware. The loop is documented in cosmic at
 locally built `lua` from THIS checkout into a measurable cosmic binary
 via `bin/make perf-bin`, and the guardrails) in
 `lib/perf/optimize/cosmopolitan.md`. Open, evidence-backed hypotheses
-targeting this repo are tracked there too:
-`grep -l "layer: cosmopolitan" lib/perf/backlog/*.md`.
+targeting this repo are tracked as GitHub issues labeled `perf` in
+whilp/cosmopolitan:
+`gh issue list --repo whilp/cosmopolitan --label perf --state open`.
 
 Short version, run from a cosmic checkout:
 


### PR DESCRIPTION
## Summary

The performance hypothesis backlog moved from cosmic's `lib/perf/backlog/*.md` files to **GitHub issues labeled `perf`**. C-layer hypotheses targeting this repo now live as `perf`-labeled issues in **whilp/cosmopolitan** (#135–#139: entries for the startup boot floor, ljson decode presize, posix_spawn binding, sigprocmask storm, and the json-encode churn that landed in #134).

This updates `AGENTS.md` so the "Performance work" section points at `gh issue list --repo whilp/cosmopolitan --label perf --state open` instead of grepping the (now removed) markdown files in the cosmic checkout.

One-line doc change; companion to whilp/cosmic's migration PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zo6kuvzgFfc6JgjHoBEUB

---
_Generated by [Claude Code](https://claude.ai/code/session_018zo6kuvzgFfc6JgjHoBEUB)_