### PR TITLE
shm: full-region read off-by-one, 32-bit futex trap, read under lock

### DIFF
--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -3547,7 +3547,9 @@ struct Memory {
 // unix.Memory:read([offset:int[, bytes:int]])
 //     └─→ str
 static int LuaUnixMemoryRead(lua_State *L) {
+  char *p;
   size_t i, n;
+  luaL_Buffer buf;
   struct Memory *m;
   m = luaL_checkudata(L, 1, "unix.Memory");
   i = luaL_optinteger(L, 2, 0);
@@ -3563,14 +3565,23 @@ static int LuaUnixMemoryRead(lua_State *L) {
     // unix.Memory:read(offset:int, bytes:int)
     // read binary data with boundary checking
     n = luaL_checkinteger(L, 3);
-    if (i > m->size || n >= m->size || i + n > m->size) {
+    if (i > m->size || n > m->size || i + n > m->size) {
       luaL_error(L, "out of range");
       __builtin_unreachable();
     }
   }
+  // Snapshot the bytes under the lock into a Lua-managed scratch buffer,
+  // then build the string AFTER releasing the lock. lua_pushlstring /
+  // luaL_pushresultsize can raise an out-of-memory error (longjmp); doing
+  // that while holding this process-shared mutex would strand the lock
+  // across every process mapping the region. luaL_buffinitsize (the only
+  // step that can fail here) runs before we take the lock, and its buffer
+  // is GC-owned so nothing leaks even if the final push longjmps.
+  p = luaL_buffinitsize(L, &buf, n);
   pthread_mutex_lock(m->lock);
-  lua_pushlstring(L, m->u.bytes + i, n);
+  memcpy(p, m->u.bytes + i, n);
   pthread_mutex_unlock(m->lock);
+  luaL_pushresultsize(&buf, n);
   return 1;
 }
 
@@ -3705,13 +3716,28 @@ static int LuaUnixMemoryXor(lua_State *L) {
 //     ├─→ nil, unix.Errno(unix.EAGAIN)
 //     └─→ nil, unix.Errno(unix.ETIMEDOUT)
 static int LuaUnixMemoryWait(lua_State *L) {
+  atomic_long *word;
   lua_Integer expect;
   int rc, olderr = errno;
   struct timespec ts, *deadline;
+  word = GetWord(L);
   expect = luaL_checkinteger(L, 3);
   if (!(INT32_MIN <= expect && expect <= INT32_MAX)) {
     luaL_argerror(L, 3, "must be an int32_t");
     __builtin_unreachable();
+  }
+  // Words are stored 64-bit (atomic_long) but the futex only ever inspects
+  // the low 32 bits (it casts to atomic_int). A word whose high 32 bits are
+  // set therefore can't be compared honestly against `expect`: e.g. a stored
+  // value of 2^32+1 would make wait(idx, 1) block as if the word held 1. Rather
+  // than silently misbehave, refuse the wait -- futex words are 32-bit.
+  {
+    long cur = atomic_load_explicit(word, memory_order_relaxed);
+    if ((uint64_t)cur >> 32) {
+      luaL_error(L, "futex word has nonzero high 32 bits (futex words are "
+                    "32-bit; store only int32 values in words you wait on)");
+      __builtin_unreachable();
+    }
   }
   if (lua_isnoneornil(L, 4)) {
     deadline = 0;  // wait forever
@@ -3721,7 +3747,7 @@ static int LuaUnixMemoryWait(lua_State *L) {
     deadline = &ts;
   }
   BEGIN_CANCELATION_POINT;
-  rc = cosmo_futex_wait((atomic_int *)GetWord(L), expect,
+  rc = cosmo_futex_wait((atomic_int *)word, expect,
                          PTHREAD_PROCESS_SHARED, CLOCK_REALTIME, deadline);
   END_CANCELATION_POINT;
   if (rc < 0) errno = -rc, rc = -1;

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -142,6 +142,10 @@ o/$(MODE)/tool/lua/test_signal.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_sign
 	$< tool/lua/test_signal.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_shm.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_shm.lua
+	$< tool/lua/test_shm.lua
+	@touch $@
+
 o/$(MODE)/tool/lua/test_isatty.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_isatty.lua
 	$< tool/lua/test_isatty.lua
 	@touch $@
@@ -165,6 +169,7 @@ TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_unix_proc.ok				\
 	o/$(MODE)/tool/lua/test_uuid.ok					\
 	o/$(MODE)/tool/lua/test_signal.ok				\
+	o/$(MODE)/tool/lua/test_shm.ok					\
 	o/$(MODE)/tool/lua/test_isatty.ok				\
 	o/$(MODE)/tool/lua/test_fetch_unix_proxy.ok			\
 	o/$(MODE)/tool/lua/test_definitions_coverage.ok

--- a/tool/lua/test_shm.lua
+++ b/tool/lua/test_shm.lua
@@ -1,0 +1,52 @@
+-- Tests for unix.mapshared / unix.Memory (shared-memory bounds + futex words).
+--
+-- Regression coverage for three shm safety fixes:
+--   1. reading the *entire* region (bytes == size) must succeed, not throw;
+--   2. wait() must reject a word whose high 32 bits are set, since the futex
+--      only compares the low 32 bits;
+--   3. read() copies under the process-shared lock but builds the Lua string
+--      after releasing it (exercised indirectly by the round-trip below).
+
+local unix = require("cosmo.unix")
+
+-- (1) off-by-one: a 64-byte map must allow read(0, 64).
+local m = assert(unix.mapshared(64))
+assert(#m:read(0, 64) == 64, "reading the full 64-byte region should succeed")
+
+-- round-trip a full-width payload through write + read
+local payload = ("ABCDEFGH"):rep(8)  -- exactly 64 bytes
+assert(#payload == 64)
+m:write(0, payload, 64)
+assert(m:read(0, 64) == payload, "full-width write/read should round-trip")
+
+-- partial reads within bounds still work
+assert(m:read(0, 1) == "A")
+assert(m:read(63, 1) == "H")
+assert(#m:read(64, 0) == 0, "zero-length read at the end is empty, not an error")
+
+-- genuine out-of-bounds reads are still rejected
+assert(not pcall(function() m:read(1, 64) end),
+  "read(1, 64) overruns a 64-byte map and must throw")
+assert(not pcall(function() m:read(0, 65) end),
+  "read(0, 65) is larger than the map and must throw")
+assert(not pcall(function() m:read(65, 0) end),
+  "offset past the end must throw")
+
+-- (2) 32-bit futex trap: a word with high bits set must be refused by wait,
+-- instead of blocking forever because the low 32 bits happen to match expect.
+m:store(0, 0x100000001)  -- 2^32 + 1; low 32 bits are 1
+assert(m:load(0) == 0x100000001, "store/load should preserve the full 64 bits")
+local ok, err = pcall(function() return m:wait(0, 1) end)
+assert(not ok, "wait on a word with nonzero high bits must error, not block")
+assert(tostring(err):find("32", 1, true),
+  "wait error should mention the 32-bit futex-word contract: " .. tostring(err))
+
+-- a well-formed (int32) word that differs from expect returns promptly
+-- (EAGAIN on futex platforms, 0 on polyfill platforms) rather than erroring,
+-- confirming the normal path still works after the guard.
+m:store(0, 0)
+local rc, e = m:wait(0, 12345)  -- 0 != 12345, so this never blocks
+assert(rc == 0 or (rc == nil and e ~= nil),
+  "an int32 word that differs from expect must not error the guard path")
+
+print("PASS")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -9173,6 +9173,13 @@ function unix.Memory:fetch_xor(word_index, value) end
 --- since the kernel can only control the ordering of wait / wake calls
 --- across processes.
 ---
+--- Futex words are 32-bit. Although words are stored as 64-bit integers,
+--- wait / wake only ever inspect the low 32 bits, so `expect` must fit in
+--- an int32 and the word you wait on must hold only int32 values. If the
+--- word at `word_index` has any of its high 32 bits set when you call
+--- wait, this method raises an error rather than silently comparing a
+--- truncated value (e.g. a stored 2^32+1 must not masquerade as 1).
+---
 --- The default behavior is to wait until the heat death of the universe
 --- if necessary. You may alternatively specify an absolute deadline. If
 --- it's less than or equal to the value returned by clock_gettime, then


### PR DESCRIPTION
Implements item 3 of #149 (batch C1 pre-stable API review). Three independent safety fixes to `unix.Memory` in `third_party/lua/lunix.c`.

## 1. `read` off-by-one — the full region was unreadable

`Memory:read(offset, bytes)` guarded with `i > m->size || n >= m->size || i + n > m->size`. The middle term rejected `bytes == size`, so `mem:read(0, 64)` on a 64-byte map threw `out of range`. The `i + n > m->size` term already covers a genuine overrun; loosened the middle term to `n > m->size`.

## 2. 32-bit futex trap

Words are stored 64-bit (`atomic_long`), but `wait`/`wake` cast to `atomic_int`, so the futex only ever compares the **low** 32 bits. A word holding `2^32 + 1` made `wait(idx, 1)` block as if the value were `1`. `wait` now loads the word first and raises an error when any of the high 32 bits are set, making the "futex words are 32-bit" contract explicit. Documented in `definitions.lua` under `unix.Memory:wait`.

## 3. `read` pushed a string while holding the process-shared mutex

`Memory:read` called `lua_pushlstring` under `m->lock`. That call can raise an out-of-memory error (longjmp), which would strand the process-shared mutex **forever, across every process** mapping the region. Now the bytes are snapshotted under the lock into a GC-owned `luaL_Buffer` (allocated *before* the lock — the only fallible step), the lock is released, and only then is the string built.

## Tests

Adds `tool/lua/test_shm.lua`:
- `#m:read(0, 64) == 64` on a 64-byte map, plus a full-width write/read round-trip;
- in-bounds partial reads and zero-length read at the end;
- out-of-bounds reads still throw;
- storing `2^32+1` and asserting `wait(0, 1)` errors (mentioning the 32-bit contract) rather than blocking;
- a normal int32 `wait` that differs from `expect` returns promptly without tripping the guard.

Wired into `tool/lua/BUILD.mk`.

## Verification

`make -j$(nproc) o//tool/lua/test` — full suite green, including `test_shm` and the `definitions.lua` coverage ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEEL2jVyRSEz8TQv9yBFtA)_