### PR TITLE
getopt: replace stateful parser with single-shot getopt.parse

### DIFF
--- a/tool/lua/test_definitions_coverage.lua
+++ b/tool/lua/test_definitions_coverage.lua
@@ -15,7 +15,7 @@
 --   * re         tool/net/lre.c               kLuaRe[] + constants + methods
 --   * argon2     tool/net/largon2.c           largon2[]
 --   * lsqlite3   tool/net/lsqlite3.c          sqlitelib[] + constants + methods
---   * getopt     tool/net/lgetopt.c           kLuaGetopt[] + parser methods
+--   * getopt     tool/net/lgetopt.c           kLuaGetopt[]
 --   * zip        tool/net/lzip.c              kLuaZip[] + Reader/Writer/Appender
 --   * repl       third_party/lua/lreplmod.c   kReplFuncs[]
 --
@@ -240,9 +240,6 @@ local MODULES = {
   {
     name = "getopt",
     fns = reg_table(C_getopt, "kLuaGetopt"),
-    methods = {
-      { class = "parser", reg = reg_table(C_getopt, "kLuaGetoptParserMethods") },
-    },
   },
   {
     name = "zip",

--- a/tool/lua/test_getopt.lua
+++ b/tool/lua/test_getopt.lua
@@ -1,216 +1,161 @@
 local getopt = require("cosmo.getopt")
 
--- Test module exists
 assert(getopt, "getopt module should exist")
-assert(type(getopt.new) == "function", "getopt.new should be a function")
+assert(type(getopt.parse) == "function", "getopt.parse should be a function")
+assert(getopt.new == nil, "the stateful getopt.new parser should be gone")
 
--- Test short options only
-local parser = getopt.new({"-h", "-v", "-o", "out.txt", "file.txt"}, "hvo:")
-local opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  opts[opt] = arg or true
+-- Collapse r.opts (a list of {opt, arg}) into a name->value map for terse
+-- assertions. Repeated options keep only their last value here.
+local function tomap(r)
+  local m = {}
+  for _, o in ipairs(r.opts) do
+    m[o.opt] = o.arg or true
+  end
+  return m
 end
-assert(opts.h == true, "opts.h should be true")
-assert(opts.v == true, "opts.v should be true")
-assert(opts.o == "out.txt", "opts.o should be 'out.txt'")
-local args = parser:remaining()
-assert(args[1] == "file.txt", "first remaining arg should be 'file.txt'")
-assert(#args == 1, "should have exactly 1 remaining arg")
-local unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
 
--- Test long options
-parser = getopt.new({"--help", "--output=foo.txt", "input.txt"}, "ho:", {
+-- Short options only
+local r = getopt.parse({"-h", "-v", "-o", "out.txt", "file.txt"}, "hvo:")
+local m = tomap(r)
+assert(m.h == true, "opts.h should be true")
+assert(m.v == true, "opts.v should be true")
+assert(m.o == "out.txt", "opts.o should be 'out.txt'")
+assert(#r.args == 1 and r.args[1] == "file.txt", "one remaining arg 'file.txt'")
+assert(#r.unknown == 0, "no unknown options")
+assert(#r.missing == 0, "no missing arguments")
+
+-- Long options (long with a short equivalent reports the short letter)
+r = getopt.parse({"--help", "--output=foo.txt", "input.txt"}, "ho:", {
   {"help", "none", "h"},
   {"output", "required", "o"},
 })
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  -- Map long options to their short equivalents for easier handling
-  if opt == "help" then opt = "h" end
-  if opt == "output" then opt = "o" end
-  opts[opt] = arg or true
-end
-assert(opts.h == true, "opts.h should be true")
-assert(opts.o == "foo.txt", "opts.o should be 'foo.txt'")
-args = parser:remaining()
-assert(args[1] == "input.txt", "remaining arg should be 'input.txt'")
-unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
+m = tomap(r)
+assert(m.h == true, "long --help maps to short 'h'")
+assert(m.o == "foo.txt", "long --output=foo.txt maps to short 'o'")
+assert(r.args[1] == "input.txt", "remaining arg 'input.txt'")
+assert(#r.unknown == 0 and #r.missing == 0)
 
--- Test long option with separate argument
-parser = getopt.new({"--output", "bar.txt"}, "o:", {
-  {"output", "required", "o"},
-})
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  if opt == "output" then opt = "o" end
-  opts[opt] = arg or true
-end
-assert(opts.o == "bar.txt", "opts.o should be 'bar.txt'")
-unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
+-- Long option with a separate argument
+r = getopt.parse({"--output", "bar.txt"}, "o:", {{"output", "required", "o"}})
+assert(tomap(r).o == "bar.txt", "long --output bar.txt")
 
--- Test combined short options
-parser = getopt.new({"-hv", "file.txt"}, "hv")
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  opts[opt] = arg or true
-end
-assert(opts.h == true, "opts.h should be true")
-assert(opts.v == true, "opts.v should be true")
-args = parser:remaining()
-assert(args[1] == "file.txt", "remaining arg should be 'file.txt'")
-unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
+-- Long-only option (no short equivalent) is reported by its long name
+r = getopt.parse({"--verbose"}, "", {{"verbose", "none"}})
+assert(tomap(r).verbose == true, "long-only option keeps its name")
 
--- Test -- terminator
-parser = getopt.new({"-h", "--", "-v", "file.txt"}, "hv")
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  opts[opt] = arg or true
-end
-assert(opts.h == true, "opts.h should be true")
-assert(opts.v == nil, "-v after -- should not be parsed as option")
-args = parser:remaining()
-assert(args[1] == "-v", "first remaining should be '-v'")
-assert(args[2] == "file.txt", "second remaining should be 'file.txt'")
-unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
+-- Combined short options
+r = getopt.parse({"-hv", "file.txt"}, "hv")
+m = tomap(r)
+assert(m.h == true and m.v == true, "combined -hv")
+assert(r.args[1] == "file.txt")
 
--- Test empty args
-parser = getopt.new({}, "hv")
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  opts[opt] = arg or true
-end
-assert(next(opts) == nil, "opts should be empty")
-args = parser:remaining()
-assert(#args == 0, "args should be empty")
-unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
+-- "--" terminator
+r = getopt.parse({"-h", "--", "-v", "file.txt"}, "hv")
+m = tomap(r)
+assert(m.h == true, "opts.h before -- parsed")
+assert(m.v == nil, "-v after -- is not an option")
+assert(r.args[1] == "-v" and r.args[2] == "file.txt", "args after -- preserved")
 
--- Test no longopts argument
-parser = getopt.new({"-h"}, "h")
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  opts[opt] = arg or true
-end
-assert(opts.h == true, "opts.h should be true without longopts arg")
-unknown = parser:unknown()
-assert(#unknown == 0, "should have no unknown options")
+-- Empty args
+r = getopt.parse({}, "hv")
+assert(#r.opts == 0 and #r.args == 0 and #r.unknown == 0 and #r.missing == 0)
 
--- Test unknown short option
-parser = getopt.new({"-h", "-x", "-v"}, "hv")
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  if opt == "?" then
-    -- Skip unknown options
-  else
-    opts[opt] = arg or true
-  end
-end
-assert(opts.h == true, "opts.h should be true")
-assert(opts.v == true, "opts.v should be true")
-assert(opts.x == nil, "opts.x should be nil (unknown)")
-unknown = parser:unknown()
-assert(#unknown == 1, "should have 1 unknown option")
-assert(unknown[1] == "x", "unknown[1] should be 'x'")
+-- No longopts argument
+r = getopt.parse({"-h"}, "h")
+assert(tomap(r).h == true, "short parse without longopts arg")
 
--- Test unknown long option
-parser = getopt.new({"--help", "--foo", "--verbose"}, "hv", {
+-- Unknown short option: recorded with its dash, absent from opts
+r = getopt.parse({"-h", "-x", "-v"}, "hv")
+m = tomap(r)
+assert(m.h == true and m.v == true)
+assert(m.x == nil, "unknown -x is not a recognized option")
+assert(#r.unknown == 1 and r.unknown[1] == "-x", "unknown carries its dash")
+assert(#r.missing == 0)
+
+-- Unknown long option keeps its dashes
+r = getopt.parse({"--help", "--foo", "--verbose"}, "hv", {
   {"help", "none", "h"},
   {"verbose", "none", "v"},
 })
-opts = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  if opt == "?" then
-    -- Skip unknown options
-  else
-    if opt == "help" then opt = "h" end
-    if opt == "verbose" then opt = "v" end
-    opts[opt] = arg or true
-  end
-end
-assert(opts.h == true, "opts.h should be true")
-assert(opts.v == true, "opts.v should be true")
-unknown = parser:unknown()
-assert(#unknown == 1, "should have 1 unknown option")
+m = tomap(r)
+assert(m.h == true and m.v == true)
+assert(#r.unknown == 1 and r.unknown[1] == "--foo", "unknown long keeps '--'")
 
--- Test multiple unknown options
-parser = getopt.new({"-x", "-y", "-z"}, "h")
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-end
-unknown = parser:unknown()
-assert(#unknown == 3, "should have 3 unknown options")
+-- Multiple unknown options
+r = getopt.parse({"-x", "-y", "-z"}, "h")
+assert(#r.unknown == 3, "three unknown options")
+assert(r.unknown[1] == "-x" and r.unknown[2] == "-y" and r.unknown[3] == "-z")
 
--- Test repeated short options
-parser = getopt.new({"-e", "foo", "-e", "bar", "-e", "spam"}, "e:")
-local e_values = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  if opt == "e" then
-    table.insert(e_values, arg)
-  end
+-- Repeated short options preserve order and every value
+r = getopt.parse({"-e", "foo", "-e", "bar", "-e", "spam"}, "e:")
+local e = {}
+for _, o in ipairs(r.opts) do
+  if o.opt == "e" then e[#e + 1] = o.arg end
 end
-assert(#e_values == 3, "should have 3 values for -e")
-assert(e_values[1] == "foo", "first -e value should be 'foo'")
-assert(e_values[2] == "bar", "second -e value should be 'bar'")
-assert(e_values[3] == "spam", "third -e value should be 'spam'")
+assert(#e == 3 and e[1] == "foo" and e[2] == "bar" and e[3] == "spam")
 
--- Test repeated long options
-parser = getopt.new({"--include", "a.h", "--include", "b.h"}, "I:", {
+-- Repeated long options
+r = getopt.parse({"--include", "a.h", "--include", "b.h"}, "I:", {
   {"include", "required", "I"},
 })
-local include_values = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  if opt == "include" or opt == "I" then
-    table.insert(include_values, arg)
-  end
+local inc = {}
+for _, o in ipairs(r.opts) do
+  if o.opt == "I" then inc[#inc + 1] = o.arg end
 end
-assert(#include_values == 2, "should have 2 values for --include")
-assert(include_values[1] == "a.h", "first --include should be 'a.h'")
-assert(include_values[2] == "b.h", "second --include should be 'b.h'")
+assert(#inc == 2 and inc[1] == "a.h" and inc[2] == "b.h")
 
--- Test mix of single and repeated options
-parser = getopt.new({"-v", "-e", "foo", "-o", "out", "-e", "bar"}, "ve:o:")
-opts = {}
-e_values = {}
-while true do
-  local opt, arg = parser:next()
-  if not opt then break end
-  if opt == "e" then
-    table.insert(e_values, arg)
-  else
-    opts[opt] = arg or true
-  end
+-- ===== TDD cases from whilp/cosmopolitan#149 item 1 =====
+
+-- (a) The old parser stored the raw optstring pointer for its lifetime without
+-- rooting the Lua string; a dynamically built optstring could be collected out
+-- from under it, turning "-x val" into an unknown option. Build the optstring
+-- via table.concat, hammer the collector, and require a clean parse.
+do
+  local optstring = table.concat({"x", ":"})  -- "x:", freshly allocated
+  collectgarbage()
+  collectgarbage()
+  local res = getopt.parse({"-x", "val"}, optstring)
+  assert(#res.opts == 1, "exactly one option parsed")
+  assert(res.opts[1].opt == "x" and res.opts[1].arg == "val",
+    "GC of the optstring must not corrupt the parse: expected x=val")
+  assert(#res.unknown == 0, "no spurious unknown option")
 end
-assert(opts.v == true, "single option should be boolean")
-assert(#e_values == 2, "should have 2 values for repeated -e")
-assert(e_values[1] == "foo" and e_values[2] == "bar", "repeated values should be correct")
-assert(opts.o == "out", "single option with arg should be string")
+
+-- (b) The old design shared global optind/opterr across parsers, so two of them
+-- corrupted each other. parse() is single-shot; interleaving two argument
+-- vectors must produce independent, repeatable results.
+do
+  local A = {"-a", "1", "-b", "posA"}
+  local B = {"-c", "-d", "posB"}
+  local a1 = getopt.parse(A, "a:b")
+  local b1 = getopt.parse(B, "cd")
+  local a2 = getopt.parse(A, "a:b")  -- re-run A after B ran in between
+  assert(tomap(a1).a == "1" and tomap(a1).b == true)
+  assert(a1.args[1] == "posA")
+  assert(tomap(b1).c == true and tomap(b1).d == true)
+  assert(b1.args[1] == "posB")
+  -- A parsed identically before and after B: no shared-state bleed.
+  assert(tomap(a2).a == "1" and tomap(a2).b == true and a2.args[1] == "posA",
+    "a re-parse must be independent of the intervening B parse")
+end
+
+-- (c) A required argument that is absent belongs in `missing`, not `unknown`.
+do
+  local res = getopt.parse({"-o"}, "o:")
+  assert(#res.missing == 1 and res.missing[1] == "o",
+    "'-o' with no argument goes to missing as 'o'")
+  assert(#res.unknown == 0, "a missing argument is not an unknown option")
+  assert(#res.opts == 0, "the incomplete option is not reported as parsed")
+end
+
+-- Malformed input returns nil + error rather than throwing
+do
+  local res, err = getopt.parse("not a table", "h")
+  assert(res == nil and type(err) == "string", "bad args -> nil, err")
+  res, err = getopt.parse({1, 2}, "h")
+  assert(res == nil and type(err) == "string", "non-string args -> nil, err")
+  res, err = getopt.parse({"-h"}, "h", {{"bad", "sometimes"}})
+  assert(res == nil and type(err) == "string", "bad has_arg -> nil, err")
+end
 
 print("PASS")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -3095,11 +3095,26 @@ function re.compile(regex, flags) end
 --- This wraps the standard GNU getopt_long(3) function for parsing command-line
 --- options with both short (-h) and long (--help) option support.
 ---
---- NOTE: This module uses global getopt state and is NOT thread-safe.
---- Do not call from multiple threads or coroutines concurrently.
+--- NOTE: This module uses process-global getopt state. `getopt.parse` consumes
+--- the whole argument vector in a single call, so back-to-back calls are
+--- independent, but do not call it concurrently from multiple threads.
 getopt = {}
 
---- Create a new getopt parser for iterating through command-line options.
+---@class getopt.Option
+--- A single recognized option and its argument (nil when the option takes
+--- none). For a long option that has a short equivalent, `opt` is that short
+--- letter; for a long-only option, `opt` is the long name.
+---@field opt string
+---@field arg string?
+
+---@class getopt.Result
+--- The outcome of a single `getopt.parse` call.
+---@field opts getopt.Option[] Recognized options, in the order encountered
+---@field args string[] Non-option (positional) arguments
+---@field unknown string[] Unrecognized options, each including its dashes
+---@field missing string[] Options that required an argument but got none
+
+--- Parse a command-line argument vector in one shot.
 ---
 --- The optstring uses standard getopt format:
 --- - A letter means that option takes no argument
@@ -3109,41 +3124,42 @@ getopt = {}
 --- The longopts table contains entries like {"name", "has_arg", "short"}:
 --- - name: the long option name (e.g., "help" for --help)
 --- - has_arg: "none", "required", or "optional"
---- - short: the equivalent short option character (e.g., "h")
+--- - short: the equivalent short option character (e.g., "h"), or nil
+---
+--- The result separates four outcomes. `opts` lists the recognized options in
+--- order, each as a {opt, arg} pair. `args` holds the leftover positional
+--- arguments. `unknown` holds unrecognized options (always spelled with their
+--- dashes, e.g. "-x" or "--nope"). `missing` holds the options that required an
+--- argument but were given none (named without dashes, e.g. "o"); this is kept
+--- distinct from `unknown` via getopt's leading-`:` protocol.
 ---
 --- Example - Basic usage:
 ---
----     local parser = getopt.new(arg, "hvo:", {
+---     local r = getopt.parse(arg, "hvo:", {
 ---       {"help",    "none",     "h"},
 ---       {"verbose", "none",     "v"},
 ---       {"output",  "required", "o"},
 ---     })
----
----     while true do
----       local opt, arg = parser:next()
----       if not opt then break end
----
----       if opt == "h" or opt == "help" then
+---     for _, o in ipairs(r.opts) do
+---       if o.opt == "h" then
 ---         print("Usage: ...")
----       elseif opt == "v" or opt == "verbose" then
+---       elseif o.opt == "v" then
 ---         verbose = true
----       elseif opt == "o" or opt == "output" then
----         output = arg
+---       elseif o.opt == "o" then
+---         output = o.arg
 ---       end
 ---     end
----
----     local remaining = parser:remaining()  -- non-option args
----     local unknown = parser:unknown()      -- unrecognized options
+---     -- r.args     -- non-option arguments
+---     -- r.unknown  -- unrecognized options, with dashes
+---     -- r.missing  -- options missing a required argument
 ---
 --- Example - Handling repeated options:
 ---
----     local parser = getopt.new(arg, "e:", {})
+---     local r = getopt.parse(arg, "e:")
 ---     local excludes = {}
----     while true do
----       local opt, arg = parser:next()
----       if not opt then break end
----       if opt == "e" then
----         table.insert(excludes, arg)
+---     for _, o in ipairs(r.opts) do
+---       if o.opt == "e" then
+---         table.insert(excludes, o.arg)
 ---       end
 ---     end
 ---     -- Now excludes contains all -e values: {"foo", "bar", "spam"}
@@ -3151,34 +3167,9 @@ getopt = {}
 ---@param args string[] Command-line arguments (typically `arg`)
 ---@param optstring string Short options string (e.g., "hvo:")
 ---@param longopts? table[] Long option definitions: {{name, has_arg, short}, ...}
----@return getopt.parser parser Parser object with next(), remaining(), and unknown() methods
-function getopt.new(args, optstring, longopts) end
-
----@class getopt.parser: userdata
---- A parser object returned by `getopt.new` for iterating through
---- command-line options.
-
---- Get the next option from the parser.
----
---- Returns the next option character or long name, along with its argument
---- if the option takes one. Returns nil when no more options remain.
----
---- If the option is unknown, returns "?" as the option name and the unknown
---- option string as the argument.
----
----@return string? opt Option character or long name, or "?" for unknown, or nil when done
----@return string? arg Option argument (for options that take arguments), or nil
-function getopt.parser:next() end
-
---- Get remaining non-option arguments after all options have been parsed.
----
----@return string[] remaining Non-option arguments
-function getopt.parser:remaining() end
-
---- Get any unknown options that were encountered during parsing.
----
----@return string[] unknown Unrecognized option strings
-function getopt.parser:unknown() end
+---@return getopt.Result result
+---@overload fun(args: string[], optstring: string, longopts?: table[]): nil, error: string
+function getopt.parse(args, optstring, longopts) end
 
 --- The path module may be used to manipulate unix paths.
 ---

--- a/tool/net/lgetopt.c
+++ b/tool/net/lgetopt.c
@@ -17,28 +17,22 @@
 │ PERFORMANCE OF THIS SOFTWARE.                                                │
 ╚─────────────────────────────────────────────────────────────────────────────*/
 #include "tool/net/lgetopt.h"
-#include "libc/mem/mem.h"
 #include "libc/str/str.h"
 #include "third_party/getopt/long1.h"
 #include "third_party/getopt/long2.h"
 #include "third_party/lua/lauxlib.h"
 #include "third_party/lua/lua.h"
 
-#define MAX_ARGC    10000
-#define MAX_LONGOPTS 1000
-#define PARSER_MT "getopt.parser"
+#define MAX_ARGC     10000
+#define MAX_LONGOPTS  1000
 
-typedef struct {
-  char **argv;
-  struct option *longopts;
-  int argc;
-  int nlong;
-  int refs_idx;        // Lua registry index for string references
-  int unknown_idx;     // Lua registry index for unknown options table
-  int unknown_count;   // Count of unknown options
-  const char *optstring;
-  int done;            // Flag indicating parsing is complete
-} GetoptParser;
+// Push `nil, <message>` and return 2 from the calling C function.
+#define FAIL(...)                     \
+  do {                                \
+    lua_pushnil(L);                   \
+    lua_pushfstring(L, __VA_ARGS__);  \
+    return 2;                         \
+  } while (0)
 
 static int ParseHasArg(const char *s) {
   if (!strcmp(s, "none"))
@@ -50,306 +44,218 @@ static int ParseHasArg(const char *s) {
   return -1;
 }
 
-// getopt.new(args, optstring, longopts) -> parser
+// getopt.parse(args, optstring[, longopts])
+//     ├─→ {opts={{opt,arg?}...}, args={...}, unknown={...}, missing={...}}
+//     └─→ nil, err
 //
-// Creates a new getopt parser that can be iterated to parse options.
-// NOTE: Uses global getopt state and is NOT thread-safe.
-static int LuaGetoptNew(lua_State *L) {
+// Single-shot, re-entrant command-line parser. Unlike the old stateful
+// Parser userdata, all state is local to this one call: the underlying
+// getopt globals (optind/opterr/optopt/optarg) are reset on entry and the
+// whole argv is consumed before returning, so two parse() calls can never
+// corrupt one another. The optstring is normalized to getopt's leading-`:`
+// protocol so a missing required argument ('missing') is reported
+// distinctly from an unrecognized option ('unknown'). 'unknown' entries
+// always carry their dashes; 'missing' entries name the bare option.
+static int LuaGetoptParse(lua_State *L) {
+  size_t olen;
+  const char *ostr;
   lua_Integer argc_raw, nlong_raw;
-  int argc, nlong, has_arg;
-  const char *optstring;
-  char **argv = NULL;
-  struct option *longopts = NULL;
-  GetoptParser *parser;
+  int argc, nlong, c, longidx = 0;
+  int n_opts = 0, n_args = 0, n_unknown = 0, n_missing = 0;
+  int T_opts, T_args, T_unknown, T_missing;
+  char **argv;
+  struct option *longopts;
+  char *opts;
 
-  luaL_checktype(L, 1, LUA_TTABLE);
-  optstring = luaL_checkstring(L, 2);
-  if (!lua_isnoneornil(L, 3))
-    luaL_checktype(L, 3, LUA_TTABLE);
+  if (!lua_istable(L, 1))
+    FAIL("args must be a table");
+  if (lua_type(L, 2) != LUA_TSTRING)
+    FAIL("optstring must be a string");
+  if (!lua_isnoneornil(L, 3) && !lua_istable(L, 3))
+    FAIL("longopts must be a table");
+  ostr = lua_tolstring(L, 2, &olen);
 
-  // Get sizes with bounds checking
+  // Bounds-check the tables before touching C memory.
   argc_raw = luaL_len(L, 1);
   if (argc_raw < 0 || argc_raw > MAX_ARGC)
-    return luaL_error(L, "args table too large (max %d)", MAX_ARGC);
+    FAIL("args table too large (max %d)", MAX_ARGC);
   argc = (int)argc_raw;
 
   nlong_raw = lua_isnoneornil(L, 3) ? 0 : luaL_len(L, 3);
   if (nlong_raw < 0 || nlong_raw > MAX_LONGOPTS)
-    return luaL_error(L, "longopts table too large (max %d)", MAX_LONGOPTS);
+    FAIL("longopts table too large (max %d)", MAX_LONGOPTS);
   nlong = (int)nlong_raw;
 
-  // Validate all longopts entries BEFORE allocating C memory
+  // Validate every longopt entry up front.
   for (int i = 0; i < nlong; i++) {
     lua_rawgeti(L, 3, i + 1);
-    if (!lua_istable(L, -1)) {
-      return luaL_error(L, "longopt[%d] must be a table", i + 1);
-    }
-    // Check name is string
+    if (!lua_istable(L, -1))
+      FAIL("longopt[%d] must be a table", i + 1);
     lua_rawgeti(L, -1, 1);
-    if (!lua_isstring(L, -1)) {
-      return luaL_error(L, "longopt[%d][1] (name) must be a string", i + 1);
-    }
+    if (lua_type(L, -1) != LUA_TSTRING)
+      FAIL("longopt[%d][1] (name) must be a string", i + 1);
     lua_pop(L, 1);
-    // Check has_arg is valid
     lua_rawgeti(L, -1, 2);
-    if (!lua_isstring(L, -1)) {
-      return luaL_error(L, "longopt[%d][2] (has_arg) must be a string", i + 1);
-    }
-    has_arg = ParseHasArg(lua_tostring(L, -1));
-    if (has_arg == -1) {
-      return luaL_error(L,
-          "longopt[%d][2] must be 'none', 'required', or 'optional'", i + 1);
-    }
+    if (lua_type(L, -1) != LUA_TSTRING)
+      FAIL("longopt[%d][2] (has_arg) must be a string", i + 1);
+    if (ParseHasArg(lua_tostring(L, -1)) == -1)
+      FAIL("longopt[%d][2] must be 'none', 'required', or 'optional'", i + 1);
     lua_pop(L, 1);
-    // Check short is string if present
     lua_rawgeti(L, -1, 3);
-    if (!lua_isnoneornil(L, -1) && !lua_isstring(L, -1)) {
-      return luaL_error(L, "longopt[%d][3] (short) must be a string or nil",
-                        i + 1);
-    }
+    if (!lua_isnoneornil(L, -1) && lua_type(L, -1) != LUA_TSTRING)
+      FAIL("longopt[%d][3] (short) must be a string or nil", i + 1);
     lua_pop(L, 1);
-    lua_pop(L, 1);  // pop longopt entry
+    lua_pop(L, 1);  // pop entry
   }
 
-  // Validate all args entries are strings
+  // Validate that every arg is a string.
   for (int i = 1; i <= argc; i++) {
     lua_rawgeti(L, 1, i);
-    if (!lua_isstring(L, -1)) {
-      return luaL_error(L, "args[%d] must be a string", i);
-    }
+    if (lua_type(L, -1) != LUA_TSTRING)
+      FAIL("args[%d] must be a string", i);
     lua_pop(L, 1);
   }
 
-  // Create parser userdata FIRST so __gc owns everything from this point on.
-  // Fields are zeroed / set to LUA_NOREF so __gc is safe if it fires before
-  // the C allocations succeed (lua_newuserdata / luaL_ref can raise OOM).
-  parser = lua_newuserdata(L, sizeof(GetoptParser));
-  parser->argv = NULL;
-  parser->longopts = NULL;
-  parser->argc = argc + 1;
-  parser->nlong = nlong;
-  parser->optstring = optstring;
-  parser->done = 0;
-  parser->unknown_count = 0;
-  parser->refs_idx = LUA_NOREF;
-  parser->unknown_idx = LUA_NOREF;
-  luaL_setmetatable(L, PARSER_MT);
+  // Scratch buffers are GC-managed userdata rather than malloc, so nothing
+  // leaks even if a later lua_push raises out-of-memory. The pointers they
+  // hold reference strings owned by the args (index 1) and longopts
+  // (index 3) tables, which stay on the stack for the whole call and so
+  // keep those strings rooted and valid for the parse.
+  argv = lua_newuserdatauv(L, (size_t)(argc + 2) * sizeof(*argv), 0);
+  longopts = lua_newuserdatauv(L, (size_t)(nlong + 1) * sizeof(*longopts), 0);
+  opts = lua_newuserdatauv(L, olen + 2, 0);
 
-  // Allocate C memory and assign into the userdata so __gc can free them.
-  argv = calloc(argc + 2, sizeof(char *));
-  if (!argv)
-    return luaL_error(L, "out of memory");
-  parser->argv = argv;
-
-  longopts = calloc(nlong + 1, sizeof(struct option));
-  if (!longopts)
-    return luaL_error(L, "out of memory");
-  parser->longopts = longopts;
-
-  // Create a table to hold references to all Lua strings
-  lua_newtable(L);
-  parser->refs_idx = luaL_ref(L, LUA_REGISTRYINDEX);
-
-  // Create unknown options table
-  lua_newtable(L);
-  parser->unknown_idx = luaL_ref(L, LUA_REGISTRYINDEX);
-
-  int ref_count = 0;
-
-  // Extract argv strings, keeping them rooted in refs table
-  lua_rawgeti(L, LUA_REGISTRYINDEX, parser->refs_idx);
-  int refs_stack = lua_gettop(L);
-
-  argv[0] = "lua";
+  argv[0] = "getopt";
   for (int i = 1; i <= argc; i++) {
     lua_rawgeti(L, 1, i);
     argv[i] = (char *)lua_tostring(L, -1);
-    lua_rawseti(L, refs_stack, ++ref_count);
+    lua_pop(L, 1);
   }
   argv[argc + 1] = NULL;
 
-  lua_pop(L, 1);  // pop refs table
-
-  // Extract longopts, keeping strings rooted
-  if (nlong > 0) {
-    lua_rawgeti(L, LUA_REGISTRYINDEX, parser->refs_idx);
-    refs_stack = lua_gettop(L);
-
-    for (int i = 0; i < nlong; i++) {
-      lua_rawgeti(L, 3, i + 1);
-
-      lua_rawgeti(L, -1, 1);
-      longopts[i].name = lua_tostring(L, -1);
-      lua_rawseti(L, refs_stack, ++ref_count);
-
-      lua_rawgeti(L, -1, 2);
-      longopts[i].has_arg = ParseHasArg(lua_tostring(L, -1));
-      lua_pop(L, 1);
-
-      lua_rawgeti(L, -1, 3);
-      if (lua_isstring(L, -1)) {
-        const char *s = lua_tostring(L, -1);
-        longopts[i].val = s[0];
-      } else {
-        longopts[i].val = 0;
-      }
-      lua_pop(L, 1);
-
-      longopts[i].flag = NULL;
-      lua_pop(L, 1);  // pop longopt entry
-    }
-
-    lua_pop(L, 1);  // pop refs table
-  }
-
-  // Reset getopt state
-  optind = 1;
-  opterr = 0;
-
-  // Return parser (already on stack)
-  return 1;
-}
-
-// parser:next() -> opt, arg
-//
-// Returns the next option and its argument (if any).
-// Returns nil when no more options.
-static int LuaGetoptNext(lua_State *L) {
-  GetoptParser *parser = luaL_checkudata(L, 1, PARSER_MT);
-
-  if (parser->done) {
-    lua_pushnil(L);
-    return 1;
-  }
-
-  int opt, longidx;
-  char shortopt[2];
-  shortopt[1] = '\0';
-
-  opt = getopt_long(parser->argc, parser->argv, parser->optstring,
-                    parser->longopts, &longidx);
-
-  if (opt == -1) {
-    parser->done = 1;
-    lua_pushnil(L);
-    return 1;
-  }
-
-  if (opt == '?') {
-    // Unknown option - record it and return "?" with the option name
-    lua_rawgeti(L, LUA_REGISTRYINDEX, parser->unknown_idx);
-    if (optopt) {
-      shortopt[0] = optopt;
-      lua_pushstring(L, shortopt);
-    } else if (parser->argv[optind - 1]) {
-      lua_pushstring(L, parser->argv[optind - 1]);
+  for (int i = 0; i < nlong; i++) {
+    lua_rawgeti(L, 3, i + 1);
+    lua_rawgeti(L, -1, 1);
+    longopts[i].name = lua_tostring(L, -1);
+    lua_pop(L, 1);
+    lua_rawgeti(L, -1, 2);
+    longopts[i].has_arg = ParseHasArg(lua_tostring(L, -1));
+    lua_pop(L, 1);
+    lua_rawgeti(L, -1, 3);
+    if (lua_type(L, -1) == LUA_TSTRING) {
+      const char *s = lua_tostring(L, -1);
+      longopts[i].val = (unsigned char)s[0];
     } else {
-      lua_pop(L, 1);  // pop unknown table
-      // Skip this unknown option and try next
-      return LuaGetoptNext(L);
+      longopts[i].val = 0;
     }
-    lua_rawseti(L, -2, ++parser->unknown_count);
-    lua_pop(L, 1);  // pop unknown table
+    lua_pop(L, 1);
+    longopts[i].flag = NULL;
+    lua_pop(L, 1);  // pop entry
+  }
+  longopts[nlong].name = NULL;
+  longopts[nlong].has_arg = 0;
+  longopts[nlong].flag = NULL;
+  longopts[nlong].val = 0;
 
-    // Return "?" and the unknown option name
-    lua_pushstring(L, "?");
-    if (optopt) {
-      shortopt[0] = optopt;
-      lua_pushstring(L, shortopt);
-    } else if (parser->argv[optind - 1]) {
-      lua_pushstring(L, parser->argv[optind - 1]);
+  // Normalize to a leading-`:` optstring so getopt returns ':' for a missing
+  // required argument and '?' for an unknown option. A leading '+'/'-' mode
+  // modifier must stay first; an existing ':' is left as-is.
+  {
+    size_t k = 0, src = 0;
+    if (olen && (ostr[0] == '+' || ostr[0] == '-'))
+      opts[k++] = ostr[src++];
+    if (!(olen > src && ostr[src] == ':'))
+      opts[k++] = ':';
+    if (olen > src) {
+      memcpy(opts + k, ostr + src, olen - src);
+      k += olen - src;
     }
-    return 2;
+    opts[k] = '\0';
   }
-
-  if (opt == 0) {
-    // Long option with flag set
-    const char *longname = parser->longopts[longidx].name;
-    lua_pushstring(L, longname);
-    if (optarg) {
-      lua_pushstring(L, optarg);
-      return 2;
-    }
-    return 1;
-  }
-
-  // Short option (or long option returning val)
-  shortopt[0] = opt;
-  lua_pushstring(L, shortopt);
-  if (optarg) {
-    lua_pushstring(L, optarg);
-    return 2;
-  }
-  return 1;
-}
-
-// parser:remaining() -> table
-//
-// Returns a table of remaining non-option arguments.
-static int LuaGetoptRemaining(lua_State *L) {
-  GetoptParser *parser = luaL_checkudata(L, 1, PARSER_MT);
 
   lua_newtable(L);
-  int j = 1;
-  for (int i = optind; i < parser->argc; i++) {
-    lua_pushstring(L, parser->argv[i]);
-    lua_rawseti(L, -2, j++);
+  T_opts = lua_gettop(L);
+  lua_newtable(L);
+  T_args = lua_gettop(L);
+  lua_newtable(L);
+  T_unknown = lua_gettop(L);
+  lua_newtable(L);
+  T_missing = lua_gettop(L);
+
+  // Reset getopt's globals for a clean single-shot parse. optreset=1 forces
+  // the BSD scanner to re-initialize its internal cursor and permutation
+  // bookkeeping, which is what makes back-to-back parse() calls independent.
+  optind = 1;
+  optreset = 1;
+  opterr = 0;
+  optarg = NULL;
+  optopt = 0;
+
+  while ((c = getopt_long(argc + 1, argv, opts, longopts, &longidx)) != -1) {
+    if (c == '?') {
+      // Unknown option; record the offending token WITH its dashes.
+      if (optopt) {
+        char tok[3] = {'-', (char)optopt, '\0'};
+        lua_pushstring(L, tok);
+      } else {
+        lua_pushstring(L, argv[optind - 1]);  // full "--name"
+      }
+      lua_rawseti(L, T_unknown, ++n_unknown);
+    } else if (c == ':') {
+      // Missing required argument; record the bare option (no dashes).
+      if (optopt) {
+        char id[2] = {(char)optopt, '\0'};
+        lua_pushstring(L, id);
+      } else {
+        // long option with no short equivalent: recover its name
+        const char *t = argv[optind - 1];
+        while (*t == '-') t++;
+        lua_pushlstring(L, t, strcspn(t, "="));
+      }
+      lua_rawseti(L, T_missing, ++n_missing);
+    } else {
+      // Recognized option: {opt=<name>, arg=<value>?}.
+      lua_createtable(L, 0, 2);
+      if (c == 0) {
+        // long option with no short equivalent
+        lua_pushstring(L, longopts[longidx].name);
+      } else {
+        char s[2] = {(char)c, '\0'};
+        lua_pushstring(L, s);
+      }
+      lua_setfield(L, -2, "opt");
+      if (optarg) {
+        lua_pushstring(L, optarg);
+        lua_setfield(L, -2, "arg");
+      }
+      lua_rawseti(L, T_opts, ++n_opts);
+    }
   }
+
+  // Everything left over is a non-option argument.
+  for (int i = optind; i <= argc; i++) {
+    lua_pushstring(L, argv[i]);
+    lua_rawseti(L, T_args, ++n_args);
+  }
+
+  lua_createtable(L, 0, 4);
+  lua_pushvalue(L, T_opts);
+  lua_setfield(L, -2, "opts");
+  lua_pushvalue(L, T_args);
+  lua_setfield(L, -2, "args");
+  lua_pushvalue(L, T_unknown);
+  lua_setfield(L, -2, "unknown");
+  lua_pushvalue(L, T_missing);
+  lua_setfield(L, -2, "missing");
   return 1;
 }
-
-// parser:unknown() -> table
-//
-// Returns a table of unknown options encountered.
-static int LuaGetoptUnknown(lua_State *L) {
-  GetoptParser *parser = luaL_checkudata(L, 1, PARSER_MT);
-  lua_rawgeti(L, LUA_REGISTRYINDEX, parser->unknown_idx);
-  return 1;
-}
-
-// Garbage collection for parser
-static int LuaGetoptParserGC(lua_State *L) {
-  GetoptParser *parser = luaL_checkudata(L, 1, PARSER_MT);
-
-  if (parser->argv) {
-    free(parser->argv);
-    parser->argv = NULL;
-  }
-  if (parser->longopts) {
-    free(parser->longopts);
-    parser->longopts = NULL;
-  }
-
-  // Unref the tables
-  luaL_unref(L, LUA_REGISTRYINDEX, parser->refs_idx);
-  luaL_unref(L, LUA_REGISTRYINDEX, parser->unknown_idx);
-
-  return 0;
-}
-
-static const luaL_Reg kLuaGetoptParserMethods[] = {
-    {"next", LuaGetoptNext},
-    {"remaining", LuaGetoptRemaining},
-    {"unknown", LuaGetoptUnknown},
-    {0},
-};
 
 static const luaL_Reg kLuaGetopt[] = {
-    {"new", LuaGetoptNew},
+    {"parse", LuaGetoptParse},
     {0},
 };
 
 int LuaGetopt(lua_State *L) {
-  // Create parser metatable
-  luaL_newmetatable(L, PARSER_MT);
-  lua_pushvalue(L, -1);
-  lua_setfield(L, -2, "__index");
-  lua_pushcfunction(L, LuaGetoptParserGC);
-  lua_setfield(L, -2, "__gc");
-  luaL_setfuncs(L, kLuaGetoptParserMethods, 0);
-  lua_pop(L, 1);
-
-  // Create getopt module table
   luaL_newlib(L, kLuaGetopt);
   return 1;
 }


### PR DESCRIPTION
Implements item 1 of #149 (batch C1 pre-stable API review). **This is a deliberate binding-contract change** — the downstream `getopt.tl` rewrite in cosmic is tracked separately in the cosmic issues.

## Problem

`getopt.new` returned a `Parser` userdata driven by `next()`/`remaining()`/`unknown()` (`tool/net/lgetopt.c`). Three defects:

1. **Use-after-free of the optstring.** The parser stored the raw `const char *` from `luaL_checkstring(L, 2)` for its whole lifetime without rooting the Lua string (argv strings *were* rooted in a registry refs table; the optstring was not). A dynamically built optstring (`table.concat`) could be collected out from under it — under GC pressure `-x val` parsed as an unknown option instead of `x="val"`.
2. **Shared global state.** The parser used the process-global `optind`/`opterr`, so two live parsers corrupted each other's scan position.
3. **Ambiguous errors.** `'?'` conflated "unknown option" and "missing required argument" — no leading-`:` protocol.

## Change

Delete the stateful userdata; one C call, local state, plain tables:

```
getopt.parse(args, optstring[, longopts])
  -> {opts={{opt=,arg=?}...}, args={...}, unknown={...}, missing={...}}
  |  nil, err
```

- **Re-entrant / single-shot.** getopt globals are reset (`optreset=1`) on entry and the whole argv is consumed before returning, so back-to-back parses are independent — no two parsers can interleave.
- **`unknown` vs `missing`.** The optstring is normalized to getopt's leading-`:` protocol. `unknown` entries always carry their dashes (`-x`, `--nope`); `missing` names the bare option that lacked its required argument (`o`).
- **Leak-safe.** Scratch buffers (`argv`, `longopts`, the normalized optstring) are GC-managed userdata holding pointers into the still-rooted `args`/`longopts` tables, so nothing leaks even if a later `lua_push` raises out-of-memory.
- The `Parser` metatable and its `__gc` are removed.

`definitions.lua` gains `getopt.Result`/`getopt.Option` records and `getopt.parse`, and drops `getopt.new` + the `getopt.parser` class. The coverage ratchet (`test_definitions_coverage.lua`) drops the getopt parser-methods entry.

## Tests

`tool/lua/test_getopt.lua` is rewritten onto `parse`, keeping the full old matrix (short/long/combined/`--`/empty/repeated/unknown) and adding the three TDD cases from the issue:
- **(a)** GC repro: a `table.concat` optstring survives `collectgarbage()` and still yields `x="val"`;
- **(b)** two interleaved argument vectors parse independently (A re-parses identically after B ran in between);
- **(c)** `parse({"-o"}, "o:")` puts `"o"` in `missing`, not `unknown`.

Plus malformed-input cases returning `nil, err`.

## Verification

`make -j$(nproc) o//tool/lua/test` — full suite green (`test_getopt` + the `definitions.lua` coverage ratchet, now 214 methods after the 3 parser methods were removed). No other repo consumer references the old `getopt.new`/parser API.

## Knock-on

`definitions.lua` change → cosmos release → cosmic pin bump → `bin/make regen-types` → `bin/make test only=gentype`; cosmic's `getopt.tl` rewrites on top of `parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEEL2jVyRSEz8TQv9yBFtA)_