### PR TITLE
signal: dispatch Lua signal handlers deferred via a debug hook

### DIFF
--- a/third_party/lua/lunix.c
+++ b/third_party/lua/lunix.c
@@ -2367,22 +2367,65 @@ static int LuaUnixSigprocmask(lua_State *L) {
   }
 }
 
+// Registry key (its unique address) for the table mapping signal number to
+// Lua handler function. Held in the Lua registry rather than a user-visible
+// global so scripts can't corrupt the dispatch table out from under us.
+static const char kSignalHandlers;
+
+// Deferred signal dispatch state. A real signal handler must not run Lua: the
+// VM it interrupts may be mid-malloc or mid-GC, and Lua is not
+// async-signal-safe. So LuaUnixOnSignal only records the signal and arms a Lua
+// debug hook -- lua_sethook is the one Lua C API that's safe from signal
+// context -- and LuaUnixSignalHook runs the Lua handler at the next VM
+// instruction boundary, in normal context.
+static volatile sig_atomic_t g_sigpending[NSIG + 1];
+static lua_Hook g_basehook;
+static int g_basehookmask;
+static int g_basehookcount;
+static int g_basehooksaved;
+
+// Runs between VM instructions after one or more signals fired. Restores the
+// hook that was active before we intercepted, then invokes each pending Lua
+// handler. Because this is ordinary VM context (not signal context), calling
+// back into Lua here is safe.
+static void LuaUnixSignalHook(lua_State *L, lua_Debug *ar) {
+  (void)ar;
+  if (g_basehooksaved) {
+    lua_sethook(L, g_basehook, g_basehookmask, g_basehookcount);
+  } else {
+    lua_sethook(L, NULL, 0, 0);
+  }
+  lua_rawgetp(L, LUA_REGISTRYINDEX, &kSignalHandlers);
+  if (lua_type(L, -1) == LUA_TTABLE) {
+    for (int sig = 1; sig <= NSIG; ++sig) {
+      if (g_sigpending[sig]) {
+        g_sigpending[sig] = 0;
+        if (lua_rawgeti(L, -1, sig) == LUA_TFUNCTION) {
+          lua_pushinteger(L, sig);
+          if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
+            ERRORF("(lua) %s failed: %s", strsignal(sig), lua_tostring(L, -1));
+            lua_pop(L, 1);  // pop error
+          }
+        } else {
+          lua_pop(L, 1);  // pop non-function
+        }
+      }
+    }
+  }
+  lua_pop(L, 1);  // pop handler table
+}
+
 static void LuaUnixOnSignal(int sig, siginfo_t *si, void *ctx) {
-  int type;
   lua_State *L = GL;
   STRACE("LuaUnixOnSignal(%G)", sig);
-  lua_getglobal(L, "__signal_handlers");
-  type = lua_rawgeti(L, -1, sig);
-  lua_remove(L, -2);  // pop __signal_handlers
-  if (type == LUA_TFUNCTION) {
-    lua_pushinteger(L, sig);
-    if (lua_pcall(L, 1, 0, 0) != LUA_OK) {
-      ERRORF("(lua) %s failed: %s", strsignal(sig), lua_tostring(L, -1));
-      lua_pop(L, 1);  // pop error
-    }
-  } else {
-    lua_pop(L, 1);  // pop handler
-  }
+  if (sig < 1 || sig > NSIG)
+    return;
+  g_sigpending[sig] = 1;
+  // Defer to LuaUnixSignalHook at the next VM boundary. lua_sethook only
+  // writes a handful of lua_State fields and is safe from signal context;
+  // actually running the Lua handler here is not.
+  lua_sethook(L, LuaUnixSignalHook,
+              LUA_MASKCALL | LUA_MASKRET | LUA_MASKLINE | LUA_MASKCOUNT, 1);
 }
 
 // unix.sigaction(sig:int[, handler:func|int[, flags:int[, mask:unix.Sigset]]])
@@ -2390,7 +2433,7 @@ static void LuaUnixOnSignal(int sig, siginfo_t *si, void *ctx) {
 //     └─→ nil, unix.Errno
 static int LuaUnixSigaction(lua_State *L) {
   sigset_t *mask;
-  int i, n, sig, olderr = errno;
+  int sig, olderr = errno;
   struct sigaction sa, oldsa, *saptr = &sa;
   sigemptyset(&sa.sa_mask);
   sig = luaL_checkinteger(L, 1);
@@ -2407,21 +2450,20 @@ static int LuaUnixSigaction(lua_State *L) {
     sa.sa_sigaction = (void *)luaL_checkinteger(L, 2);
   } else if (lua_isfunction(L, 2)) {
     sa.sa_sigaction = LuaUnixOnSignal;
-    // lua probably isn't async signal safe, so...
-    // let's mask all the lua handlers during handling
+    // The C handler only records the signal and arms a debug hook, so it no
+    // longer runs Lua in signal context; there's no need to mask every other
+    // Lua handler. Just avoid re-entering the handler for the same signal.
     sigaddset(&sa.sa_mask, sig);
-    lua_getglobal(L, "__signal_handlers");
-    luaL_checktype(L, -1, LUA_TTABLE);
-    lua_len(L, -1);
-    n = lua_tointeger(L, -1);
-    lua_pop(L, 1);
-    for (i = 1; i <= MIN(n, NSIG); ++i) {
-      if (lua_geti(L, -1, i) == LUA_TFUNCTION) {
-        sigaddset(&sa.sa_mask, i);
-      }
-      lua_pop(L, 1);
+    // Remember the debug hook that was active before we start intercepting, so
+    // LuaUnixSignalHook can restore it. Captured once: this C call is itself a
+    // VM boundary, so any previously armed dispatch hook has already fired and
+    // lua_gethook returns the genuine base hook rather than our own.
+    if (!g_basehooksaved) {
+      g_basehook = lua_gethook(L);
+      g_basehookmask = lua_gethookmask(L);
+      g_basehookcount = lua_gethookcount(L);
+      g_basehooksaved = 1;
     }
-    lua_pop(L, 1);
   } else {
     luaL_argerror(L, 2, "sigaction handler not integer or function");
     __builtin_unreachable();
@@ -2438,8 +2480,8 @@ static int LuaUnixSigaction(lua_State *L) {
     lua_remove(L, 3);
   }
   if (!sigaction(sig, saptr, &oldsa)) {
-    lua_getglobal(L, "__signal_handlers");
-    // push the old handler result to stack. if the global lua handler
+    lua_rawgetp(L, LUA_REGISTRYINDEX, &kSignalHandlers);
+    // push the old handler result to stack. if the registry handler
     // table has a real function, then we prefer to return that. if it's
     // absent or a raw integer value, then we're better off returning
     // what the kernel gave us in &oldsa.
@@ -2448,7 +2490,7 @@ static int LuaUnixSigaction(lua_State *L) {
       lua_pushinteger(L, (intptr_t)oldsa.sa_handler);
     }
     if (saptr) {
-      // update the global lua table
+      // update the registry lua table
       if (sa.sa_sigaction == LuaUnixOnSignal) {
         lua_pushvalue(L, -3);
       } else {
@@ -4274,7 +4316,7 @@ int LuaUnix(lua_State *L) {
   LuaUnixStatObj(L);
   LuaUnixDirObj(L);
   lua_newtable(L);
-  lua_setglobal(L, "__signal_handlers");
+  lua_rawsetp(L, LUA_REGISTRYINDEX, &kSignalHandlers);
 
   LoadMagnums(L, kIpOptnames, "IP_");
   LoadMagnums(L, kTcpOptnames, "TCP_");

--- a/tool/lua/BUILD.mk
+++ b/tool/lua/BUILD.mk
@@ -138,6 +138,10 @@ o/$(MODE)/tool/lua/test_uuid.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_uuid.l
 	$< tool/lua/test_uuid.lua
 	@touch $@
 
+o/$(MODE)/tool/lua/test_signal.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_signal.lua
+	$< tool/lua/test_signal.lua
+	@touch $@
+
 o/$(MODE)/tool/lua/test_isatty.ok: o/$(MODE)/tool/lua/lua.dbg tool/lua/test_isatty.lua
 	$< tool/lua/test_isatty.lua
 	@touch $@
@@ -160,6 +164,7 @@ TOOL_LUA_TESTS =							\
 	o/$(MODE)/tool/lua/test_zip_security.ok				\
 	o/$(MODE)/tool/lua/test_unix_proc.ok				\
 	o/$(MODE)/tool/lua/test_uuid.ok					\
+	o/$(MODE)/tool/lua/test_signal.ok				\
 	o/$(MODE)/tool/lua/test_isatty.ok				\
 	o/$(MODE)/tool/lua/test_fetch_unix_proxy.ok			\
 	o/$(MODE)/tool/lua/test_definitions_coverage.ok

--- a/tool/lua/test_signal.lua
+++ b/tool/lua/test_signal.lua
@@ -1,0 +1,75 @@
+-- Stress test for deferred Lua signal dispatch (whilp/cosmopolitan#149 item 4).
+--
+-- The old unix.sigaction ran the Lua handler with lua_pcall directly inside the
+-- real signal handler. A signal landing while the VM was mid-malloc or mid-GC
+-- could re-enter the allocator/collector and corrupt the heap, so this exact
+-- workload -- a tight table-allocation loop peppered with a 1ms timer signal --
+-- crashed intermittently. With deferred dispatch the C handler only sets a flag
+-- and arms a debug hook, and the Lua handler runs at the next VM instruction
+-- boundary in normal context, so the same workload must run clean.
+
+local unix = require("cosmo.unix")
+
+-- Basic delivery: a handler installed via sigaction runs, exactly once per
+-- signal, and receives the signal number.
+do
+  local seen = {}
+  unix.sigaction(unix.SIGUSR1, function(sig) seen[#seen + 1] = sig end)
+  unix.raise(unix.SIGUSR1)
+  for i = 1, 1000 do local _ = {i} end  -- give the VM boundaries to run the hook
+  unix.raise(unix.SIGUSR1)
+  for i = 1, 1000 do local _ = {i} end
+  assert(#seen == 2, "expected 2 deliveries, got " .. #seen)
+  assert(seen[1] == unix.SIGUSR1 and seen[2] == unix.SIGUSR1,
+    "handler should receive the signal number")
+  -- restore default so it can't fire during later work
+  unix.sigaction(unix.SIGUSR1, unix.SIG_DFL)
+end
+
+-- The handler table lives in the Lua registry now, not a global, so scripts
+-- can't see or corrupt it.
+assert(_G.__signal_handlers == nil,
+  "the signal handler table must not be exposed as a global")
+
+-- Stress: 1ms ITIMER_REAL firing SIGALRM into a Lua handler while the main
+-- thread churns table allocations (and thus GC) for ~2 seconds.
+do
+  local fired = 0
+  unix.sigaction(unix.SIGALRM, function() fired = fired + 1 end)
+
+  local function now()
+    local s, ns = unix.clock_gettime()
+    return s + ns / 1e9
+  end
+
+  -- 1ms initial + 1ms interval => a SIGALRM roughly every millisecond.
+  assert(unix.setitimer(unix.ITIMER_REAL, 0, 1e6, 0, 1e6),
+    "setitimer(ITIMER_REAL) should arm")
+
+  local deadline = now() + 2.0
+  local sink
+  local iters = 0
+  while now() < deadline do
+    -- allocate churn to keep the collector busy; the hazard the old code hit
+    -- was a signal landing mid-allocation / mid-collection.
+    for _ = 1, 200 do
+      sink = {1, 2, 3, {4, 5, {6, 7, 8}}, "x" .. iters}
+    end
+    iters = iters + 1
+  end
+  local _ = sink
+
+  -- disarm the timer, then drop the handler
+  unix.setitimer(unix.ITIMER_REAL, 0, 0, 0, 0)
+  unix.sigaction(unix.SIGALRM, unix.SIG_DFL)
+
+  -- If we got here we didn't crash. The timer should have fired many times
+  -- over ~2s of 1ms ticks; require at least a handful to prove signals were
+  -- actually being delivered into Lua throughout the churn.
+  assert(iters > 0, "the allocation loop should have run")
+  assert(fired >= 10,
+    "SIGALRM should have been delivered to the Lua handler repeatedly, got " ..
+    fired)
+end
+
+print("PASS")

--- a/tool/net/definitions.lua
+++ b/tool/net/definitions.lua
@@ -8143,6 +8143,18 @@ function unix.sigprocmask(how, newmask) end
 ---     assert(gotsigusr1)
 ---     assert(unix.sigprocmask(unix.SIG_SETMASK, oldmask))
 ---
+--- When `handler` is a Lua function, it is dispatched *deferred* rather than
+--- from the raw signal context: the real signal handler only records the
+--- signal and the Lua function is then invoked at the next Lua VM instruction
+--- boundary, in normal execution context. This is required because the Lua VM
+--- is not async-signal-safe -- running Lua from a true signal handler that
+--- interrupted the VM mid-allocation or mid-GC can corrupt the heap. A
+--- consequence is that a blocking syscall interrupted by the signal still
+--- returns `EINTR` immediately (so `sigsuspend`/poll wakeups are preserved),
+--- but the Lua handler body runs a moment later once the VM resumes. Integer
+--- handlers (e.g. `unix.SIG_IGN`, `unix.SIG_DFL`, or a raw function pointer)
+--- are installed directly and are not deferred.
+---
 --- It's a good idea to not do too much work in a signal handler.
 ---
 ---@param mask? unix.Sigset


### PR DESCRIPTION
Implements item 4 of #149 (batch C1 pre-stable API review).

## Problem

`LuaUnixOnSignal` (`third_party/lua/lunix.c`) ran the Lua handler with `lua_pcall` **directly inside the real signal handler**. Lua is not async-signal-safe: a signal landing while the VM is mid-malloc or mid-GC can re-enter the allocator/collector and corrupt the heap. The in-code comment acknowledged Lua isn't async-signal-safe but only masked *other* Lua handlers — which doesn't address running the interrupted VM itself. The handler registry was also the user-visible, user-corruptible global `__signal_handlers`.

## Change — standard deferred dispatch

- The C signal handler now only sets `volatile sig_atomic_t g_sigpending[sig]` and arms a Lua debug hook via `lua_sethook` — the one Lua C API that's safe from signal context. (This is exactly how Lua's own CLI defers SIGINT.)
- `LuaUnixSignalHook` runs at the next VM instruction boundary, in normal context: it restores the hook that was active before we intercepted, then invokes each pending Lua handler. A blocking syscall interrupted by the signal still returns `EINTR` first, so `sigsuspend`/poll wakeups are preserved — only the handler *body* runs a moment later.
- The handler table moves from the global `__signal_handlers` into the Lua **registry** (keyed by a private static address), so scripts can't tamper with the dispatch table. The base debug hook is captured once (at first Lua-handler install) so the hook can be restored afterward.
- Integer handlers (`SIG_IGN`/`SIG_DFL`/raw pointer) are still installed directly and are not deferred.

## Tests

Adds `tool/lua/test_signal.lua`:
- once-per-signal delivery with the correct signal number;
- assertion that `_G.__signal_handlers` no longer exists;
- **the stress test from the issue**: a ~2s tight table-allocation loop under a 1ms `ITIMER_REAL` SIGALRM handler. This intermittently crashed under the old in-context dispatch and now runs clean, with the handler confirmed to have fired repeatedly throughout the churn.

`definitions.lua`'s `unix.sigaction` documents the deferred semantics. Wired into `tool/lua/BUILD.mk`.

## Verification

`make -j$(nproc) o//tool/lua/test` — full suite green (`test_signal` + the `definitions.lua` coverage ratchet). No other repo code referenced `__signal_handlers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEEL2jVyRSEz8TQv9yBFtA)_